### PR TITLE
fix: make sure that anchor tags don't overflow

### DIFF
--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -254,6 +254,7 @@ pre {
 a {
     color: $clickable;
     text-decoration: none;
+    word-break: break-all;
 }
 
 a:visited {


### PR DESCRIPTION
Occasionally I have noticed on mobile that links with long unbroken text (git hashes for example) can cause the anchor tag to overflow its container and then the whole document starts scrolling horizontally which is not what we want. 

I _think_ this is a safe solution. 