### PR TITLE
feat: move ledger to stable memory

### DIFF
--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -504,7 +504,7 @@ impl State {
 
     pub fn load(&mut self) {
         assets::load();
-        match token::balances_from_ledger(&self.ledger) {
+        match token::balances_from_ledger(&self.memory.ledger) {
             Ok(balances) => {
                 for user in self.users.values_mut() {
                     user.balance = balances
@@ -2697,7 +2697,7 @@ impl State {
                 tx.from.owner = new_principal;
             }
         }
-        match token::balances_from_ledger(&self.ledger) {
+        match token::balances_from_ledger(&self.memory.ledger) {
             Ok(balances) => {
                 let user = self.users.get_mut(&user_id).expect("no user found");
                 user.balance = balances


### PR DESCRIPTION
This change moves all transactions to the stable memory. The PR is based upon the block spaced memory allocation. The reason for this change is that the block size chosen in the previous PR can fit almost any ledger transaction. This way, new transactions will be put into the holes decreasing the fragmentation.