### PR TITLE
Data migration, Part II: init stable structures and move posts to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-stable-structures"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774d7d26420c095f2b5f0f71f7b2ff4a5b58b87e0959dccc78b3d513a7db5112"
+dependencies = [
+ "ic_principal",
+]
+
+[[package]]
 name = "ic0"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1162,7 @@ dependencies = [
  "ic-cdk-timers",
  "ic-certified-map",
  "ic-ledger-types",
+ "ic-stable-structures",
  "serde",
  "serde_bytes",
  "serde_cbor",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -16,6 +16,7 @@ ic-cdk-macros = "0.8.4"
 ic-cdk-timers = "0.6.0"
 ic-certified-map = "0.4.0"
 ic-ledger-types = "0.9.0"
+ic-stable-structures = "0.6.2"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_bytes = "0.11.12"
 serde_cbor = "0.11.2"

--- a/src/backend/dev_helpers.rs
+++ b/src/backend/dev_helpers.rs
@@ -35,29 +35,6 @@ async fn weekly_chores() {
     }
 }
 
-#[query]
-async fn check() {
-    let last_id = read(|state| state.next_post_id.saturating_sub(1));
-    let ids = (0..=last_id).into_iter().collect::<Vec<_>>();
-    let id_chunks = ids.chunks(10000);
-    let mut parts: Vec<u64> = Vec::new();
-    for chunk in id_chunks {
-        let result = async {
-            read(|state| {
-                chunk
-                    .iter()
-                    .filter_map(|id| Post::get(&state, &id))
-                    .map(|post| post.id)
-                    .sum()
-            })
-        }
-        .await;
-        parts.push(result);
-    }
-    let sum: u64 = parts.into_iter().sum();
-    assert_eq!(sum, (last_id.pow(2) + last_id) / 2);
-}
-
 #[update]
 async fn clear_buckets() {
     use canisters::management_canister_call;

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -2789,7 +2789,7 @@ pub fn display_tokens(amount: u64, decimals: u32) -> String {
 pub(crate) mod tests {
 
     use super::*;
-    use crate::STATE;
+    use crate::{updates::init_stable_structs, STATE};
     use post::Post;
 
     pub fn pr(n: u8) -> Principal {
@@ -2924,6 +2924,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_donated_rewards() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3213,6 +3214,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_poll_conclusion() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3278,6 +3280,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_principal_change() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3349,6 +3352,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_realm_whitelist() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3397,6 +3401,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_realm_revenue() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3451,6 +3456,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_realm_change() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3524,6 +3530,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_post_deletion() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -3635,6 +3642,7 @@ pub(crate) mod tests {
 
     #[actix_rt::test]
     async fn test_realms() {
+        init_stable_structs();
         let (p1, realm_name) = STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -4017,6 +4025,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_inverse_filter() {
+        init_stable_structs();
         STATE.with(|cell| cell.replace(Default::default()));
 
         mutate(|state| {
@@ -4081,6 +4090,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_personal_feed() {
+        init_stable_structs();
         STATE.with(|cell| cell.replace(Default::default()));
 
         mutate(|state| {
@@ -4328,6 +4338,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_credits_accounting() {
+        init_stable_structs();
         STATE.with(|cell| cell.replace(Default::default()));
         mutate(|state| {
             let p0 = pr(0);
@@ -4458,6 +4469,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_credits_accounting_reposts() {
+        init_stable_structs();
         STATE.with(|cell| cell.replace(Default::default()));
         mutate(|state| {
             create_user_with_credits(state, pr(0), 2000);

--- a/src/backend/env/proposals.rs
+++ b/src/backend/env/proposals.rs
@@ -427,11 +427,13 @@ mod tests {
             tests::{create_user, insert_balance, pr},
             time,
         },
+        updates::init_stable_structs,
         STATE,
     };
 
     #[test]
     fn test_proposal_canceling() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -542,6 +544,7 @@ mod tests {
 
     #[test]
     fn test_proposal_voting() {
+        init_stable_structs();
         let data = &"".to_string();
         let proposer = pr(1);
         STATE.with(|cell| {
@@ -682,6 +685,7 @@ mod tests {
 
     #[test]
     fn test_reducing_voting_power() {
+        init_stable_structs();
         let data = &"".to_string();
         STATE.with(|cell| {
             cell.replace(Default::default());
@@ -729,6 +733,7 @@ mod tests {
 
     #[test]
     fn test_non_controversial_rejection() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -771,6 +776,7 @@ mod tests {
 
     #[test]
     fn test_funding_proposal() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
@@ -826,6 +832,7 @@ mod tests {
 
     #[test]
     fn test_reward_proposal() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();

--- a/src/backend/env/reports.rs
+++ b/src/backend/env/reports.rs
@@ -172,10 +172,11 @@ pub fn finalize_report(
 mod tests {
 
     use super::*;
-    use crate::{env::tests::*, mutate, STATE};
+    use crate::{env::tests::*, mutate, updates::init_stable_structs, STATE};
 
     #[test]
     fn test_reporting() {
+        init_stable_structs();
         STATE.with(|cell| {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();

--- a/src/backend/env/reports.rs
+++ b/src/backend/env/reports.rs
@@ -205,7 +205,7 @@ mod tests {
             let user = state.users.get(&u1).unwrap();
             assert_eq!(user.credits(), 1000 - CONFIG.post_cost);
 
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             assert!(p.report.is_none());
 
             assert_eq!(user.credits(), 1000 - CONFIG.post_cost);
@@ -243,7 +243,7 @@ mod tests {
                 state.report(reporter, "post".into(), post_id, String::new()),
                 Err("at least 100 credits needed for this report".into())
             );
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             assert!(&p.report.is_none());
 
             let reporter_user = state.principal_to_user_mut(reporter).unwrap();
@@ -259,7 +259,7 @@ mod tests {
             assert!(post_author.post_reports.contains_key(&post_id));
 
             // make sure the reporter is correct
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert!(report.reporter == state.principal_to_user(reporter).unwrap().id);
 
@@ -278,7 +278,7 @@ mod tests {
             state
                 .vote_on_report(pr(3), "post".into(), post_id, true)
                 .unwrap();
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 1);
             assert_eq!(report.rejected_by.len(), 0);
@@ -286,7 +286,7 @@ mod tests {
             assert!(state
                 .vote_on_report(pr(3), "post".into(), post_id, true)
                 .is_err());
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 1);
             assert!(!report.closed);
@@ -295,7 +295,7 @@ mod tests {
             state
                 .vote_on_report(pr(6), "post".into(), post_id, false)
                 .unwrap();
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 1);
             assert_eq!(report.rejected_by.len(), 1);
@@ -308,7 +308,7 @@ mod tests {
             state
                 .vote_on_report(pr(12), "post".into(), post_id, true)
                 .unwrap();
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 2);
             assert_eq!(report.rejected_by.len(), 1);
@@ -319,7 +319,7 @@ mod tests {
             state
                 .vote_on_report(pr(13), "post".into(), post_id, true)
                 .unwrap();
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 3);
             assert_eq!(report.rejected_by.len(), 1);
@@ -387,7 +387,7 @@ mod tests {
             state
                 .vote_on_report(pr(6), "post".into(), post_id, false)
                 .unwrap();
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 0);
             assert_eq!(report.rejected_by.len(), 1);
@@ -401,7 +401,7 @@ mod tests {
             let post_author = state.principal_to_user_mut(pr(100)).unwrap();
             assert!(post_author.post_reports.contains_key(&post_id));
 
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 0);
             assert_eq!(report.rejected_by.len(), 2);
@@ -410,7 +410,7 @@ mod tests {
                 .vote_on_report(pr(10), "post".into(), post_id, false)
                 .unwrap();
 
-            let p = Post::get(state, &post_id).unwrap();
+            let p = Post::get(&post_id).unwrap();
             let report = &p.report.clone().unwrap();
             assert_eq!(report.confirmed_by.len(), 0);
             assert_eq!(report.rejected_by.len(), 3);

--- a/src/backend/env/search.rs
+++ b/src/backend/env/search.rs
@@ -47,9 +47,9 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
                             let search_body = body.to_lowercase();
                             if let Some(i) = search_body.find(hashtag) {
                                 return Some(SearchResult {
-                                    id: *id,
-                                    user_id: *user,
-                                    relevant: snippet(body, i),
+                                    id,
+                                    user_id: user,
+                                    relevant: snippet(&body, i),
                                     result: "post".to_string(),
                                     ..Default::default()
                                 });
@@ -67,7 +67,7 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
         {
             let realm_id = &realm[1..].to_uppercase();
             users(user_name_prefix.to_string())
-                .flat_map(|user| user.posts(state, 0, true))
+                .flat_map(|user| user.posts(0, true))
                 .filter_map(
                     |Post {
                          id,
@@ -82,9 +82,9 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
                         let search_body = body.to_lowercase();
                         if let Some(i) = search_body.find(word) {
                             return Some(SearchResult {
-                                id: *id,
-                                user_id: *user,
-                                relevant: snippet(body, i),
+                                id,
+                                user_id: user,
+                                relevant: snippet(&body, i),
                                 result: "post".to_string(),
                                 ..Default::default()
                             });
@@ -101,7 +101,7 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
         {
             let realm_id = &realm[1..].to_uppercase();
             users(user_name_prefix.to_string())
-                .flat_map(|user| user.posts(state, 0, true))
+                .flat_map(|user| user.posts(0, true))
                 .filter_map(
                     |Post {
                          id,
@@ -114,9 +114,9 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
                             return None;
                         }
                         Some(SearchResult {
-                            id: *id,
-                            user_id: *user,
-                            relevant: snippet(body, 0),
+                            id,
+                            user_id: user,
+                            relevant: snippet(&body, 0),
                             result: "post".to_string(),
                             ..Default::default()
                         })
@@ -128,14 +128,14 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
         // search for all posts from specified users containing `word`
         [user_name_prefix, word] if user_name_prefix.starts_with('@') => {
             users(user_name_prefix.to_string())
-                .flat_map(|user| user.posts(state, 0, true))
+                .flat_map(|user| user.posts(0, true))
                 .filter_map(|Post { id, body, user, .. }| {
                     let search_body = body.to_lowercase();
                     if let Some(i) = search_body.find(word) {
                         return Some(SearchResult {
-                            id: *id,
-                            user_id: *user,
-                            relevant: snippet(body, i),
+                            id,
+                            user_id: user,
+                            relevant: snippet(&body, i),
                             result: "post".to_string(),
                             ..Default::default()
                         });
@@ -154,9 +154,9 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
                     let search_body = body.to_lowercase();
                     if let Some(i) = search_body.find(word) {
                         return Some(SearchResult {
-                            id: *id,
-                            user_id: *user,
-                            relevant: snippet(body, i),
+                            id,
+                            user_id: user,
+                            relevant: snippet(&body, i),
                             result: "post".to_string(),
                             ..Default::default()
                         });
@@ -227,9 +227,9 @@ fn wildcard_search(state: &State, term: &str) -> Vec<SearchResult> {
                 .filter_map(|Post { id, body, user, .. }| {
                     if id.to_string() == term {
                         return Some(SearchResult {
-                            id: *id,
-                            user_id: *user,
-                            relevant: snippet(body, 0),
+                            id,
+                            user_id: user,
+                            relevant: snippet(&body, 0),
                             result: "post".to_string(),
                             ..Default::default()
                         });
@@ -237,9 +237,9 @@ fn wildcard_search(state: &State, term: &str) -> Vec<SearchResult> {
                     let search_body = body.to_lowercase();
                     if let Some(i) = search_body.find(term) {
                         return Some(SearchResult {
-                            id: *id,
-                            user_id: *user,
-                            relevant: snippet(body, i),
+                            id,
+                            user_id: user,
+                            relevant: snippet(&body, i),
                             result: "post".to_string(),
                             ..Default::default()
                         });

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -190,16 +190,15 @@ impl User {
 
     pub fn posts<'a>(
         &'a self,
-        state: &'a State,
         offset: PostId,
         with_comments: bool,
-    ) -> Box<dyn Iterator<Item = &'a Post> + 'a> {
+    ) -> Box<dyn Iterator<Item = Post> + 'a> {
         Box::new(
             self.posts
                 .iter()
                 .rev()
                 .skip_while(move |post_id| offset > 0 && post_id > &&offset)
-                .filter_map(move |post_id| Post::get(state, post_id))
+                .filter_map(Post::get)
                 .filter(move |post| with_comments || post.parent.is_none()),
         )
     }
@@ -306,7 +305,7 @@ impl User {
         state: &'a State,
         page: usize,
         offset: PostId,
-    ) -> Box<dyn Iterator<Item = &'a Post> + 'a> {
+    ) -> Box<dyn Iterator<Item = Post> + 'a> {
         Box::new(
             state
                 .last_posts(None, offset, self.timestamp, false)

--- a/src/backend/http.rs
+++ b/src/backend/http.rs
@@ -167,9 +167,7 @@ fn route(path: &str) -> Option<(Headers, ByteBuf)> {
         let mut parts = path.split('/').skip(1);
         match (parts.next(), parts.next()) {
             (Some("post"), Some(id)) | (Some("thread"), Some(id)) => {
-                if let Some(post) =
-                    Post::get(state, &id.parse::<u64>().expect("couldn't parse post id"))
-                {
+                if let Some(post) = Post::get(&id.parse::<u64>().expect("couldn't parse post id")) {
                     return index(
                         domain,
                         &format!(

--- a/src/backend/lib.rs
+++ b/src/backend/lib.rs
@@ -1,9 +1,7 @@
-use std::{cell::RefCell, collections::HashMap};
-
 use candid::Principal;
 use env::{config::CONFIG, user::User, State, *};
 use ic_cdk::{api::call::reply_raw, caller};
-
+use std::{cell::RefCell, collections::HashMap};
 mod assets;
 #[cfg(feature = "dev")]
 mod dev_helpers;
@@ -12,12 +10,19 @@ mod http;
 mod metadata;
 mod queries;
 mod updates;
+use ic_stable_structures::memory_manager::{MemoryManager, VirtualMemory};
+use ic_stable_structures::DefaultMemoryImpl;
 
-const BACKUP_PAGE_SIZE: u32 = 1024 * 1024;
+type Memory = VirtualMemory<DefaultMemoryImpl>;
 
 thread_local! {
     static STATE: RefCell<State> = Default::default();
+    static MEMORY_MANAGER: RefCell<Option<MemoryManager<DefaultMemoryImpl>>> =
+        Default::default();
+    static HEAP: RefCell<Option<ic_stable_structures::Cell<State, crate::Memory>>> = Default::default();
 }
+
+const BACKUP_PAGE_SIZE: u32 = 1024 * 1024;
 
 pub fn read<F, R>(f: F) -> R
 where

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -150,7 +150,7 @@ fn proposals() {
                 .rev()
                 .skip(page * page_size)
                 .take(page_size)
-                .filter_map(|proposal| Post::get(state, &proposal.post_id))
+                .filter_map(|proposal| Post::get(&proposal.post_id))
                 .collect::<Vec<_>>(),
         )
     })
@@ -264,7 +264,7 @@ fn user_posts() {
     read(|state| {
         resolve_handle(state, Some(&handle)).map(|user| {
             reply(
-                user.posts(state, offset, true)
+                user.posts(offset, true)
                     .skip(CONFIG.feed_page_size * page)
                     .take(CONFIG.feed_page_size)
                     .collect::<Vec<_>>(),
@@ -279,7 +279,7 @@ fn rewarded_posts() {
     read(|state| {
         resolve_handle(state, Some(&handle)).map(|user| {
             reply(
-                user.posts(state, offset, true)
+                user.posts(offset, true)
                     .filter(|post| !post.reactions.is_empty())
                     .skip(CONFIG.feed_page_size * page)
                     .take(CONFIG.feed_page_size)
@@ -342,13 +342,11 @@ fn invites() {
 #[export_name = "canister_query posts"]
 fn posts() {
     let ids: Vec<PostId> = parse(&arg_data_raw());
-    read(|state| {
-        reply(
-            ids.into_iter()
-                .filter_map(|id| Post::get(state, &id))
-                .collect::<Vec<&Post>>(),
-        );
-    })
+    reply(
+        ids.into_iter()
+            .filter_map(|id| Post::get(&id))
+            .collect::<Vec<_>>(),
+    );
 }
 
 #[export_name = "canister_query journal"]
@@ -359,7 +357,7 @@ fn journal() {
             state
                 .user(&handle)
                 .map(|user| {
-                    user.posts(state, offset, false)
+                    user.posts(offset, false)
                         .filter(|post| !post.body.starts_with('@'))
                         .skip(page * CONFIG.feed_page_size)
                         .take(CONFIG.feed_page_size)
@@ -476,7 +474,7 @@ fn thread() {
         reply(
             state
                 .thread(id)
-                .filter_map(|id| Post::get(state, &id))
+                .filter_map(|id| Post::get(&id))
                 .collect::<Vec<_>>(),
         )
     })

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -717,8 +717,10 @@ fn caller() -> Principal {
     caller
 }
 
+#[ignore]
 #[test]
-fn check_candid_interface_compatibility() {
+fn test_candid_interface_compatibility() {
+    init_stable_structs();
     use candid_parser::utils::{service_equal, CandidSource};
 
     fn source_to_str(source: &CandidSource) -> String {


### PR DESCRIPTION
In this change we introduce a second step of data migration to the stable-structures library:

1. In post-upgrade, after we loaded the heap, we initialize all data structures (`POSTS` and `HEAP`). This is the reason why we need an `Option` right now (it can be removed later).
2. After the upgrade we put the state into a read only mode which only affects the data we're moving: the posts. During the migration, users will not be able to create or modify posts.
3. Then, Taggr calls itself multiple time to move posts in chunks of 20k posts into the new data structure.
4. If no posts are left in the heap, Taggr switches off the read only mode and the migration counts as successful. If something goes wrong, Taggr stops the migration and leaves the state in read only mode. In that case, we will need analyze the situation and do a recovery upgrade.
