### PR TITLE
Remove data pre-loading

### DIFF
--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -662,12 +662,12 @@ impl State {
             let mut old_names = Vec::default();
             let mut new_names = Vec::default();
             for user_id in &realm.controllers {
-                let controller = self.users.get_mut(&user_id).expect("no user found");
+                let controller = self.users.get_mut(user_id).expect("no user found");
                 controller.controlled_realms.remove(&realm_id);
                 old_names.push(controller.name.clone());
             }
             for user_id in &controllers {
-                let controller = self.users.get_mut(&user_id).expect("no user found");
+                let controller = self.users.get_mut(user_id).expect("no user found");
                 controller.controlled_realms.insert(realm_id.clone());
                 new_names.push(controller.name.clone());
             }

--- a/src/backend/env/post.rs
+++ b/src/backend/env/post.rs
@@ -143,15 +143,14 @@ impl Post {
     /// Returns the post with some meta information needed for by the UI.
     pub fn with_meta<'a>(&'a self, state: &'a State) -> (&'_ Self, Meta<'_>) {
         let user = state.users.get(&self.user).expect("no user found");
+        let realm = self
+            .realm
+            .as_ref()
+            .and_then(|realm_id| state.realms.get(realm_id));
         let meta = Meta {
             author_name: user.name.as_str(),
             author_rewards: user.rewards(),
-            realm_color: self.realm.as_ref().and_then(|realm_id| {
-                state
-                    .realms
-                    .get(realm_id)
-                    .map(|realm| realm.label_color.as_str())
-            }),
+            realm_color: realm.map(|realm| realm.label_color.as_str()),
         };
         (self, meta)
     }

--- a/src/backend/env/post.rs
+++ b/src/backend/env/post.rs
@@ -50,6 +50,13 @@ pub enum Extension {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]
+pub struct Meta<'a> {
+    author_name: &'a str,
+    author_rewards: i64,
+    realm_color: Option<&'a str>,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct Post {
     pub id: PostId,
     pub body: String,
@@ -131,6 +138,22 @@ impl Post {
             realm,
             heat,
         }
+    }
+
+    /// Returns the post with some meta information needed for by the UI.
+    pub fn with_meta<'a>(&'a self, state: &'a State) -> (&'_ Self, Meta<'_>) {
+        let user = state.users.get(&self.user).expect("no user found");
+        let meta = Meta {
+            author_name: user.name.as_str(),
+            author_rewards: user.rewards(),
+            realm_color: self.realm.as_ref().and_then(|realm_id| {
+                state
+                    .realms
+                    .get(realm_id)
+                    .map(|realm| realm.label_color.as_str())
+            }),
+        };
+        (self, meta)
     }
 
     pub fn creation_timestamp(&self) -> u64 {

--- a/src/backend/env/post.rs
+++ b/src/backend/env/post.rs
@@ -143,7 +143,7 @@ impl Post {
         }
     }
 
-    /// Returns the post with some meta information needed for by the UI.
+    /// Returns the post with some meta information needed by the UI.
     pub fn with_meta<'a>(&'a self, state: &'a State) -> (&'_ Self, Meta<'_>) {
         let user = state.users.get(&self.user).expect("no user found");
         let realm = self

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -109,8 +109,9 @@ pub struct User {
     pub downvotes: BTreeMap<UserId, Time>,
     pub show_posts_in_realms: bool,
     pub posts: Vec<PostId>,
-    #[serde(default)]
     pub miner: bool,
+    #[serde(default)]
+    pub controlled_realms: HashSet<RealmId>,
 }
 
 impl User {
@@ -163,6 +164,7 @@ impl User {
             followers: Default::default(),
             accounting: Default::default(),
             controllers: Default::default(),
+            controlled_realms: Default::default(),
             last_activity: timestamp,
             stalwart: false,
             invited_by: None,

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -741,7 +741,7 @@ mod tests {
         let donor = state.users.get_mut(&donor_id).unwrap();
 
         // Assume the donor minted 6k tokens
-        assert_eq!(donor.minted, 6000);
+        assert_eq!(state.minting_power.get(&pr(0)).unwrap(), &6000);
 
         // Simulate a tx to the cold wallet
         donor.balance -= 5500;

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -41,13 +41,12 @@ pub struct Draft {
     pub blobs: Vec<(String, Blob)>,
 }
 
-#[derive(Default, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserFilter {
     age_days: u64,
     safe: bool,
     balance: Token,
     num_followers: usize,
-    #[serde(default)]
     downvotes: usize,
 }
 

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -215,30 +215,6 @@ fn sorted_realms(
     Box::new(realms.into_iter())
 }
 
-#[export_name = "canister_query realms_data"]
-fn realms_data() {
-    read(|state| {
-        let user_id = state.principal_to_user(caller()).map(|user| user.id);
-        reply(
-            state
-                .realms
-                .iter()
-                .filter(|(_, realm)| realm.last_update + 2 * WEEK > time())
-                .map(|(name, realm)| {
-                    (
-                        name,
-                        (
-                            &realm.label_color,
-                            user_id.map(|id| realm.controllers.contains(&id)),
-                            &realm.filter,
-                        ),
-                    )
-                })
-                .collect::<BTreeMap<_, _>>(),
-        );
-    });
-}
-
 #[export_name = "canister_query realms"]
 fn realms() {
     let realm_ids: Vec<String> = parse(&arg_data_raw());

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -80,21 +80,15 @@ fn post_upgrade() {
 
 fn sync_post_upgrade_fixtures() {
     mutate(|state| {
-        // Fill the root posts index.
-        state.root_posts_index = (0..state.next_post_id)
-            .filter_map(|id| Post::get(state, &id))
-            .filter_map(|post| post.parent.is_none().then_some(post.id))
-            .collect();
-
-        // Remove user report according to DAO poll: https://6qfxa-ryaaa-aaaai-qbhsq-cai.icp0.io/#/post/621615
-        if let Some(zikhas) = state.users.get_mut(&789) {
-            assert_eq!(zikhas.name, "Zikhas");
-            zikhas.report.take();
-        }
-
-        // Init all users as minters
-        for user in state.users.values_mut() {
-            user.miner = true;
+        for (realm_id, realm) in state.realms.iter().clone() {
+            for user_id in &realm.controllers {
+                state
+                    .users
+                    .get_mut(&user_id)
+                    .unwrap()
+                    .controlled_realms
+                    .insert(realm_id.clone());
+            }
         }
     })
 }

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -84,7 +84,7 @@ fn sync_post_upgrade_fixtures() {
             for user_id in &realm.controllers {
                 state
                     .users
-                    .get_mut(&user_id)
+                    .get_mut(user_id)
                     .unwrap()
                     .controlled_realms
                     .insert(realm_id.clone());

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -120,7 +120,7 @@ export const ApiGenerator = (
                 identity,
             );
             if (response.status != "replied") {
-                console.error(response);
+                console.error(methodName, response);
                 return null;
             }
             return response.reply.arg;

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -574,6 +574,7 @@ export const UserLink = ({
     const [userName, setUserName] = React.useState<string | undefined>(name);
 
     const loadUserName = async () => {
+        if (id > Number.MAX_SAFE_INTEGER) return;
         const data = await window.api.query<UserData>("users_data", [id]);
         if (data) setUserName(data[id]);
     };
@@ -596,18 +597,25 @@ export const UserLink = ({
 
 export const UserList = ({
     ids,
+    loadedNames = {},
     profile,
 }: {
     ids: UserId[];
+    loadedNames?: UserData;
     profile?: boolean;
 }) => {
-    const [names, setNames] = React.useState<UserData>({});
+    const [names, setNames] = React.useState<UserData>(loadedNames);
 
     const loadNames = async () =>
-        setNames((await window.api.query<UserData>("users_data", ids)) || {});
+        setNames(
+            (await window.api.query<UserData>(
+                "users_data",
+                ids.filter((id) => id < Number.MAX_SAFE_INTEGER),
+            )) || {},
+        );
 
     React.useEffect(() => {
-        if (ids) loadNames();
+        if (ids || !loadedNames) loadNames();
     }, []);
 
     return Object.keys(names).length == 0 ? (

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -580,7 +580,7 @@ export const UserLink = ({
     };
 
     React.useEffect(() => {
-        if (!userName) loadUserName();
+        if (!userName && id != null) loadUserName();
     }, [userName]);
 
     return userName ? (
@@ -615,11 +615,11 @@ export const UserList = ({
         );
 
     React.useEffect(() => {
-        if (ids || !loadedNames) loadNames();
+        if (ids && Object.entries(loadedNames).length == 0) loadNames();
     }, []);
 
     return Object.keys(names).length == 0 ? (
-        <Loading />
+        <Loading spaced={false} />
     ) : (
         commaSeparated(
             ids.map((id) => (

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -616,12 +616,14 @@ export const UserList = ({
                 {},
         );
 
+    const namesPending =
+        removeNAs(ids).length > 0 && Object.entries(loadedNames).length == 0;
+
     React.useEffect(() => {
-        if (removeNAs(ids) && Object.entries(loadedNames).length == 0)
-            loadNames();
+        if (namesPending) loadNames();
     }, []);
 
-    return Object.keys(names).length == 0 && removeNAs(ids).length > 0 ? (
+    return namesPending ? (
         <Loading spaced={false} />
     ) : (
         commaSeparated(

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -595,8 +595,12 @@ export const UserLink = ({
     );
 };
 
+// We use u64::MAX to denote anonymous users. We should filter them out before we try to load user data.
+const removeNAs = (ids: UserId[]) =>
+    ids.filter((id) => id < Number.MAX_SAFE_INTEGER);
+
 export const UserList = ({
-    ids,
+    ids = [],
     loadedNames = {},
     profile,
 }: {
@@ -608,17 +612,16 @@ export const UserList = ({
 
     const loadNames = async () =>
         setNames(
-            (await window.api.query<UserData>(
-                "users_data",
-                ids.filter((id) => id < Number.MAX_SAFE_INTEGER),
-            )) || {},
+            (await window.api.query<UserData>("users_data", removeNAs(ids))) ||
+                {},
         );
 
     React.useEffect(() => {
-        if (ids && Object.entries(loadedNames).length == 0) loadNames();
+        if (removeNAs(ids) && Object.entries(loadedNames).length == 0)
+            loadNames();
     }, []);
 
-    return Object.keys(names).length == 0 ? (
+    return Object.keys(names).length == 0 && removeNAs(ids).length > 0 ? (
         <Loading spaced={false} />
     ) : (
         commaSeparated(

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -609,21 +609,25 @@ export const UserList = ({
     profile?: boolean;
 }) => {
     const [names, setNames] = React.useState<UserData>(loadedNames);
+    const [loading, setLoading] = React.useState(false);
 
-    const loadNames = async () =>
+    const loadNames = async () => {
+        setLoading(true);
         setNames(
             (await window.api.query<UserData>("users_data", removeNAs(ids))) ||
                 {},
         );
-
-    const namesPending =
-        removeNAs(ids).length > 0 && Object.entries(loadedNames).length == 0;
+        setLoading(false);
+    };
 
     React.useEffect(() => {
+        const namesPending =
+            removeNAs(ids).length > 0 &&
+            Object.entries(loadedNames).length == 0;
         if (namesPending) loadNames();
     }, []);
 
-    return namesPending ? (
+    return loading ? (
         <Loading spaced={false} />
     ) : (
         commaSeparated(

--- a/src/frontend/src/content.tsx
+++ b/src/frontend/src/content.tsx
@@ -206,7 +206,8 @@ const markdownizer = (
             components={{
                 h1: ({ node, children, ...props }) => {
                     if (!blogTitle) return <h1 {...props}>{children}</h1>;
-                    let { author, created, length, realm } = blogTitle;
+                    let { author, created, length, realm, background } =
+                        blogTitle;
                     return (
                         <>
                             <h1>{children}</h1>
@@ -219,6 +220,7 @@ const markdownizer = (
                                         &nbsp;&nbsp;&middot;&nbsp;&nbsp;
                                         <RealmSpan
                                             name={realm}
+                                            background={background}
                                             classNameArg="realm_tag"
                                             styleArg={{ borderRadius: "5px" }}
                                         />

--- a/src/frontend/src/dashboard.tsx
+++ b/src/frontend/src/dashboard.tsx
@@ -5,10 +5,10 @@ import {
     timeAgo,
     hoursTillNext,
     HeadBar,
-    userList,
     icpCode,
     IcpAccountLink,
     USD_PER_XDR,
+    UserList,
 } from "./common";
 import { Content } from "./content";
 import {
@@ -264,7 +264,7 @@ export const Dashboard = ({}) => {
                 <hr />
                 <div>
                     <h2>STALWARTS</h2>
-                    {userList(stats.stalwarts)}
+                    <UserList ids={stats.stalwarts} />
                 </div>
                 <hr />
                 {logSelector}

--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -80,7 +80,7 @@ export const Form = ({
     const form = React.useRef();
     const tags = window.backendCache.recent_tags;
     const users = Object.values(window.backendCache.followees);
-    const realms = Object.keys(window.backendCache.realms_data);
+    const realms = Object.keys(window.user?.realms);
     const { max_post_length, max_blob_size_bytes } = window.backendCache.config;
 
     const previewAtLeft = bigScreen() && !comment;

--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -79,7 +79,7 @@ export const Form = ({
     const textarea = React.useRef<HTMLTextAreaElement>();
     const form = React.useRef();
     const tags = window.backendCache.recent_tags;
-    const users = Object.values(window.backendCache.users);
+    const users = Object.values(window.backendCache.followees);
     const realms = Object.keys(window.backendCache.realms_data);
     const { max_post_length, max_blob_size_bytes } = window.backendCache.config;
 

--- a/src/frontend/src/header.tsx
+++ b/src/frontend/src/header.tsx
@@ -201,7 +201,11 @@ const UserSection = ({ user }: { user: UserType }) => {
                 {user && (
                     <span className="xx_large_text bottom_spaced">
                         <User classNameArg="right_half_spaced" />{" "}
-                        <UserLink profile={true} id={user.id} />
+                        <UserLink
+                            profile={true}
+                            id={user.id}
+                            name={user.name}
+                        />
                     </span>
                 )}
 

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -32,7 +32,7 @@ import { Tokens, TransactionView, TransactionsView } from "./tokens";
 import { Whitepaper } from "./whitepaper";
 import { Recovery } from "./recovery";
 import { MAINNET_MODE, CANISTER_ID } from "./env";
-import { PostId, User, UserData, UserFilter } from "./types";
+import { PostId, User, UserData } from "./types";
 import { setRealmUI, setUI } from "./theme";
 import { Search } from "./search";
 import { Distribution } from "./distribution";
@@ -242,18 +242,14 @@ const App = () => {
 
 const reloadCache = async () => {
     window.backendCache = window.backendCache || { users: [], recent_tags: [] };
-    const [recent_tags, stats, config, realms] = await Promise.all([
+    const [recent_tags, stats, config] = await Promise.all([
         window.api.query<[string, any][]>("recent_tags", "", 500),
         window.api.query<any>("stats"),
         window.api.query<any>("config"),
-        window.api.query<{ [key: string]: [string, boolean, UserFilter] }>(
-            "realms_data",
-        ),
     ]);
     window.backendCache = {
         followees: {},
         recent_tags: (recent_tags || []).map(([tag, _]) => tag),
-        realms_data: realms || {},
         stats,
         config,
     };

--- a/src/frontend/src/journal.tsx
+++ b/src/frontend/src/journal.tsx
@@ -37,7 +37,11 @@ export const Journal = ({ handle }: { handle: string }) => {
             {profile && (
                 <div className="text_centered">
                     <h1>
-                        <UserLink id={profile.id} profile={true} />
+                        <UserLink
+                            id={profile.id}
+                            name={profile.name}
+                            profile={true}
+                        />
                         's Journal
                     </h1>
                     {

--- a/src/frontend/src/poll.tsx
+++ b/src/frontend/src/poll.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ButtonWithLoading, userList } from "./common";
+import { ButtonWithLoading, UserList } from "./common";
 import { Content } from "./content";
 import { Poll, PostId } from "./types";
 
@@ -110,7 +110,7 @@ export const PollView = ({
                                             className="active"
                                         ></div>
                                         <div className="small_text top_half_spaced">
-                                            {userList(data.votes[id])}
+                                            <UserList ids={data.votes[id]} />
                                         </div>
                                     </div>
                                 </div>

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -46,7 +46,7 @@ import {
     More,
 } from "./icons";
 import { ProposalView } from "./proposals";
-import { Post, PostId, Realm, UserId } from "./types";
+import { Post, PostId, Realm, UserData, UserId } from "./types";
 import { MAINNET_MODE } from "./env";
 
 export const PostView = ({
@@ -472,16 +472,24 @@ const PostInfo = ({
     writingCallback: () => void;
 }) => {
     const [realmData, setRealmData] = React.useState<Realm | null>();
+    const [userData, setUserData] = React.useState<UserData>();
 
-    const loadRealmData = async () => {
-        setRealmData(
-            ((await window.api.query<Realm[]>("realms", [post.realm])) ||
-                [])[0],
-        );
+    const loadData = async () => {
+        // @ts-ignore
+        const ids: UserId[] = [].concat(...Object.values(reactions));
+        if (ids.length > 0)
+            setUserData(
+                (await window.api.query<UserData>("users_data", ids)) || {},
+            );
+        if (post.realm)
+            setRealmData(
+                ((await window.api.query<Realm[]>("realms", [post.realm])) ||
+                    [])[0],
+            );
     };
 
     React.useEffect(() => {
-        if (post.realm) loadRealmData();
+        loadData();
     }, []);
 
     const user = window.user;
@@ -762,7 +770,11 @@ const PostInfo = ({
                         {Object.entries(reactions).map(([reactId, users]) => (
                             <div key={reactId} className="bottom_half_spaced">
                                 {reaction2icon(Number(reactId))}{" "}
-                                <UserList ids={users} profile={true} />
+                                <UserList
+                                    ids={users}
+                                    loadedNames={userData}
+                                    profile={true}
+                                />
                             </div>
                         ))}
                     </div>

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -500,7 +500,7 @@ const PostInfo = ({
 
     const postAuthor = user?.id == post.user;
     const realmController =
-        realmData && realmData.controllers.includes(user?.id);
+        user && user.controlled_realms.includes(post.realm || "");
     const { token_symbol, token_decimals } = window.backendCache.config;
     return (
         <div className="left_half_spaced right_half_spaced top_spaced">

--- a/src/frontend/src/post_feed.tsx
+++ b/src/frontend/src/post_feed.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { bigScreen, isRoot, Loading, expandUser } from "./common";
+import { bigScreen, expandMeta, isRoot, Loading } from "./common";
 import { PostView } from "./post";
-import { Post, PostId } from "./types";
+import { Meta, Post, PostId } from "./types";
 
 export const PostFeed = ({
     classNameArg,
@@ -22,7 +22,7 @@ export const PostFeed = ({
         page: number,
         offset: number,
         comments?: boolean,
-    ) => Promise<Post[] | null>;
+    ) => Promise<[Post, Meta][] | null>;
     heartbeat?: any;
     title?: JSX.Element;
     thread?: boolean;
@@ -57,13 +57,13 @@ export const PostFeed = ({
     const loadPage = async (page: number) => {
         // only show the loading indicator on the first load
         setLoading(refreshBeat == 0);
-        const loadedPost = await feedLoader(
+        const loadedPosts = await feedLoader(
             page,
             page == 0 ? 0 : offset,
             !!includeComments,
         );
-        if (!loadedPost) return;
-        let nextPosts = loadedPost.map(expandUser);
+        if (!loadedPosts) return;
+        let nextPosts = loadedPosts.map(expandMeta);
         setPosts(page == 0 ? nextPosts : posts.concat(nextPosts));
         if (page == 0 && nextPosts.length > 0) setOffset(nextPosts[0].id);
         if (nextPosts.length < window.backendCache.config.feed_page_size)

--- a/src/frontend/src/profile.tsx
+++ b/src/frontend/src/profile.tsx
@@ -6,7 +6,6 @@ import {
     commaSeparated,
     Loading,
     HeadBar,
-    userList,
     bigScreen,
     tokenBalance,
     FlagButton,
@@ -17,6 +16,7 @@ import {
     popUp,
     RealmList,
     noiseControlBanner,
+    UserList,
 } from "./common";
 import { Content } from "./content";
 import { Journal } from "./icons";
@@ -292,7 +292,7 @@ export const UserInfo = ({
                     profile.followers.length,
                     <>
                         <h2>Followers</h2>
-                        {userList(profile.followers)}
+                        <UserList ids={profile.followers} />
                     </>,
                 )}
             </div>
@@ -467,9 +467,7 @@ export const UserInfo = ({
                     <div className="db_cell">
                         INVITED BY
                         <span>
-                            <a
-                                href={`/#/user/${inviter}`}
-                            >{`${window.backendCache.users[inviter]}`}</a>
+                            <UserLink id={inviter} />
                         </span>
                     </div>
                 )}

--- a/src/frontend/src/profile.tsx
+++ b/src/frontend/src/profile.tsx
@@ -21,13 +21,12 @@ import {
 import { Content } from "./content";
 import { Journal } from "./icons";
 import { PostFeed } from "./post_feed";
-import { PostId, Realm, User, UserId } from "./types";
+import { PostId, User, UserId } from "./types";
 import { Principal } from "@dfinity/principal";
 
 export const Profile = ({ handle }: { handle: string }) => {
     const [status, setStatus] = React.useState(0);
     const [profile, setProfile] = React.useState({} as User);
-    const [controlledRealms, setControlledRealms] = React.useState<string[]>();
     const [tab, setTab] = React.useState("LAST");
 
     const updateState = async () => {
@@ -38,14 +37,6 @@ export const Profile = ({ handle }: { handle: string }) => {
         }
         setStatus(1);
         setProfile(profile);
-        const realms = (
-            (await window.api.query<Realm[]>("realms", profile.realms)) || []
-        ).map((realm, i): [string, Realm] => [profile.realms[i], realm]);
-        setControlledRealms(
-            realms
-                .filter(([_, realm]) => realm.controllers.includes(profile.id))
-                .map(([realm_id, _]: [string, Realm]) => realm_id),
-        );
     };
 
     React.useEffect(() => {
@@ -214,10 +205,7 @@ export const Profile = ({ handle }: { handle: string }) => {
                     domain="misbehaviour"
                 />
             )}
-            <UserInfo
-                profile={profile}
-                controlledRealms={controlledRealms || []}
-            />
+            <UserInfo profile={profile} />
             <PostFeed
                 title={title}
                 useList={true}
@@ -250,13 +238,7 @@ export const Profile = ({ handle }: { handle: string }) => {
     );
 };
 
-export const UserInfo = ({
-    profile,
-    controlledRealms,
-}: {
-    profile: User;
-    controlledRealms: string[];
-}) => {
+export const UserInfo = ({ profile }: { profile: User }) => {
     const placeholder = (label: number, content: any) =>
         status ? (
             <div className="small_text">{content}</div>
@@ -481,12 +463,12 @@ export const UserInfo = ({
                     <hr />
                 </>
             )}
-            {controlledRealms.length > 0 && (
+            {profile.controlled_realms.length > 0 && (
                 <>
                     <h2>Controls realms</h2>
                     <RealmList
                         classNameArg="top_spaced"
-                        ids={controlledRealms}
+                        ids={profile.controlled_realms}
                     />
                     <hr />
                 </>

--- a/src/frontend/src/proposals.tsx
+++ b/src/frontend/src/proposals.tsx
@@ -4,7 +4,6 @@ import {
     ButtonWithLoading,
     timeAgo,
     token,
-    userList,
     percentage,
     FileUploadInput,
     tokenBalance,
@@ -12,12 +11,13 @@ import {
     tokens,
     hex,
     UserLink,
+    UserList,
 } from "./common";
 import * as React from "react";
 import { Content } from "./content";
 import { HourGlass } from "./icons";
 import { PostFeed } from "./post_feed";
-import { PostId, Proposal } from "./types";
+import { PostId, Proposal, User } from "./types";
 
 const REPO_RELEASE = "https://github.com/TaggrNetwork/taggr/releases/latest";
 const REPO_COMMIT = "https://github.com/TaggrNetwork/taggr/commit";
@@ -118,21 +118,18 @@ export const Proposals = () => {
                                     alert("Error: incomplete data.");
                                     return;
                                 }
-                                const userEntry = Object.entries(
-                                    window.backendCache.users,
-                                ).find(
-                                    ([_, name]) =>
-                                        name.toLowerCase() ==
-                                        userName.toLowerCase(),
+                                const user = await window.api.query<User>(
+                                    "user",
+                                    [name],
                                 );
-                                if (!userEntry) {
+                                if (!user) {
                                     alert(`No user ${userName} found!`);
                                     return;
                                 }
                                 let response = await window.api.call<any>(
                                     "propose_add_realm_controller",
                                     description,
-                                    Number(userEntry[0]),
+                                    user.id,
                                     realmId.toUpperCase(),
                                 );
                                 if ("Err" in response) {
@@ -339,7 +336,6 @@ export const ProposalView = ({
     id: number;
     postId: PostId;
 }) => {
-    const users = window.backendCache.users;
     const [status, setStatus] = React.useState(0);
     const [proposal, setProposal] = React.useState<Proposal>();
 
@@ -585,12 +581,11 @@ export const ProposalView = ({
                     ({percentage(adopted, proposal.voting_power)})
                 </div>
                 <div className="small_text">
-                    {users &&
-                        userList(
-                            proposal.bulletins
-                                .filter((vote) => vote[1])
-                                .map((vote) => vote[0]),
-                        )}
+                    <UserList
+                        ids={proposal.bulletins
+                            .filter((vote) => vote[1])
+                            .map((vote) => vote[0])}
+                    />
                 </div>
             </div>
             <div className="bottom_spaced">
@@ -606,12 +601,11 @@ export const ProposalView = ({
                     ({percentage(rejected, proposal.voting_power)})
                 </div>
                 <div className="small_text">
-                    {users &&
-                        userList(
-                            proposal.bulletins
-                                .filter((vote) => !vote[1])
-                                .map((vote) => vote[0]),
-                        )}
+                    <UserList
+                        ids={proposal.bulletins
+                            .filter((vote) => !vote[1])
+                            .map((vote) => vote[0])}
+                    />
                 </div>
             </div>
             {window.user && open && !voted && (

--- a/src/frontend/src/realms.tsx
+++ b/src/frontend/src/realms.tsx
@@ -6,11 +6,11 @@ import {
     noiseControlBanner,
     HeadBar,
     Loading,
-    realmColors,
     RealmSpan,
     setTitle,
     ToggleButton,
     UserList,
+    foregroundColor,
 } from "./common";
 import { Content } from "./content";
 import { Close } from "./icons";
@@ -228,7 +228,7 @@ export const RealmForm = ({ existingName }: { existingName?: string }) => {
                     />
                     <RealmSpan
                         classNameArg="realm_tag"
-                        col={label_color}
+                        background={label_color}
                         name={name}
                     />
                 </div>
@@ -562,7 +562,10 @@ export const RealmHeader = ({ name }: { name: string }) => {
 
     if (!realm) return <Loading />;
 
-    const colors = realmColors(name);
+    const colors = {
+        background: realm.label_color,
+        color: foregroundColor(realm.label_color),
+    };
     const user = window.user;
     return (
         <>

--- a/src/frontend/src/realms.tsx
+++ b/src/frontend/src/realms.tsx
@@ -17,6 +17,8 @@ import { Close } from "./icons";
 import { getTheme, setRealmUI } from "./theme";
 import { Realm, Theme, User, UserFilter } from "./types";
 
+let timer: any = null;
+
 export const RealmForm = ({ existingName }: { existingName?: string }) => {
     const editing = !!existingName;
     const userId = window.user.id;
@@ -57,6 +59,9 @@ export const RealmForm = ({ existingName }: { existingName?: string }) => {
         if (existingName) setName(existingName);
         setRealm(realm);
         if (realm.theme) setTheme(JSON.parse(realm.theme));
+    };
+
+    const setStrings = async () => {
         setWhitelistString(
             Object.values(
                 (await window.api.query<{ [id: number]: string }>(
@@ -106,8 +111,13 @@ export const RealmForm = ({ existingName }: { existingName?: string }) => {
     };
 
     React.useEffect(() => {
-        validateUserNames();
+        clearTimeout(timer);
+        timer = setTimeout(validateUserNames, 1500);
     }, [controllersString, whitelistString]);
+
+    React.useEffect(() => {
+        setStrings();
+    }, [realm]);
 
     React.useEffect(() => {
         if (editing) loadRealm();
@@ -691,8 +701,6 @@ export const RealmHeader = ({ name }: { name: string }) => {
         </>
     );
 };
-
-let timer: any = null;
 
 export const Realms = () => {
     const [realms, setRealms] = React.useState<[string, Realm][]>([]);

--- a/src/frontend/src/search.tsx
+++ b/src/frontend/src/search.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Loading, ShareButton } from "./common";
+import { Loading, ShareButton, UserLink } from "./common";
 import { PostId, UserId } from "./types";
 
 type SearchResult = {
@@ -116,11 +116,7 @@ const renderResult = ({
     if (result == "user")
         return (
             <span>
-                User{" "}
-                <a
-                    href={`#/user/${id}`}
-                >{`@${window.backendCache.users[id]}`}</a>
-                : {relevant || "no info."}
+                User <UserLink id={id} />: {relevant || "no info."}
             </span>
         );
     if (result == "tag")
@@ -139,12 +135,8 @@ const renderResult = ({
     if (result == "post")
         return (
             <span>
-                <a href={`#/post/${id}`}>{`Post ${id}`}</a> by&nbsp;
-                <a
-                    href={`#/user/${user_id}`}
-                >{`@${window.backendCache.users[user_id]}`}</a>
-                :&nbsp;
-                {relevant}
+                <a href={`#/post/${id}`}>{`Post ${id}`}</a> by{" "}
+                <UserLink id={user_id} /> {relevant}
             </span>
         );
     return "can't render";

--- a/src/frontend/src/tokens.tsx
+++ b/src/frontend/src/tokens.tsx
@@ -88,15 +88,6 @@ export const Tokens = () => {
     ) {
         vp += balanceAmounts.shift() || 0;
     }
-    const userToPrincipal = balances.reduce(
-        (acc, balance) => {
-            const userName = window.backendCache.users[balance[2]];
-            if (userName)
-                acc[userName.toLowerCase()] = balance[0].owner.toString();
-            return acc;
-        },
-        {} as { [name: string]: string },
-    );
     const { e8s_for_one_xdr, e8s_revenue_per_1k } = window.backendCache.stats;
     const holders = balances.length;
 
@@ -108,9 +99,7 @@ export const Tokens = () => {
     }
     let searchedPrincipal;
     try {
-        searchedPrincipal = Principal.fromText(
-            userToPrincipal[query.toLowerCase()] || query,
-        ).toString();
+        searchedPrincipal = Principal.fromText(query).toString();
     } catch (_) {}
     return (
         <>
@@ -406,7 +395,11 @@ export const TransactionsView = ({
                         {identifiedUser && (
                             <>
                                 <h3 className="larger_text ">
-                                    User <UserLink id={identifiedUser.id} />
+                                    User{" "}
+                                    <UserLink
+                                        id={identifiedUser.id}
+                                        name={identifiedUser.name}
+                                    />
                                 </h3>
                                 <Content value={identifiedUser.about} />
                             </>

--- a/src/frontend/src/tokens.tsx
+++ b/src/frontend/src/tokens.tsx
@@ -178,9 +178,9 @@ export const Tokens = () => {
                 </div>
                 <h2>Top 100 token holders</h2>
                 <div className="row_container bottom_spaced">
-                    {balances.slice(0, 100).map((b) => (
+                    {balances.slice(0, 100).map((b, i) => (
                         <div
-                            key={b[0].owner.toString()}
+                            key={i}
                             style={{
                                 height: "5em",
                                 width: percentage(b[1], mintedSupply),
@@ -208,8 +208,8 @@ export const Tokens = () => {
                         style={{ textAlign: "right" }}
                         className={bigScreen() ? "" : "small_text"}
                     >
-                        {balances.slice(0, (balPage + 1) * 25).map((b) => (
-                            <tr key={b[0].owner.toString()}>
+                        {balances.slice(0, (balPage + 1) * 25).map((b, i) => (
+                            <tr key={i}>
                                 <td style={{ textAlign: "left" }}>
                                     {showPrincipal(b[0])}
                                 </td>

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -95,6 +95,12 @@ export type Realm = {
     posts: PostId[];
 };
 
+export type Meta = {
+    author_name: string;
+    author_rewards: number;
+    realm_color: string[];
+};
+
 export type Post = {
     id: PostId;
     parent?: PostId;
@@ -102,7 +108,6 @@ export type Post = {
     children: PostId[];
     reposts: PostId[];
     user: UserId;
-    userObject: { id: UserId; name: string; rewards: number };
     report?: Report;
     body: string;
     effBody: string;
@@ -116,6 +121,7 @@ export type Post = {
     extension: Extension;
     tree_size: number;
     tree_update: BigInt;
+    meta: Meta;
 };
 
 export type BlogTitle = {
@@ -231,6 +237,7 @@ export type Report = {
 };
 
 export type Theme = { [name: string]: any };
+export type UserData = { [id: UserId]: string };
 
 declare global {
     interface Window {
@@ -252,8 +259,7 @@ declare global {
         lastSavedUpgrade: number;
         uiInitialized: boolean;
         backendCache: {
-            users: { [name: UserId]: string };
-            rewards: { [name: UserId]: number };
+            followees: UserData;
             recent_tags: string[];
             realms_data: { [name: string]: [string, boolean, UserFilter] };
             stats: {

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -213,6 +213,7 @@ export type User = {
     timestamp: bigint;
     active_weeks: number;
     invited_by?: UserId;
+    controlled_realms: RealmId[];
     about: string;
     rewards: number;
     cycles: number;

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -98,7 +98,7 @@ export type Realm = {
 export type Meta = {
     author_name: string;
     author_rewards: number;
-    realm_color: string[];
+    realm_color: string;
 };
 
 export type Post = {
@@ -129,6 +129,7 @@ export type BlogTitle = {
     realm?: string;
     created: BigInt;
     length: number;
+    background: string;
 };
 
 export type Account = {
@@ -261,7 +262,6 @@ declare global {
         backendCache: {
             followees: UserData;
             recent_tags: string[];
-            realms_data: { [name: string]: [string, boolean, UserFilter] };
             stats: {
                 fees_burned: number;
                 volume_day: number;

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -98,6 +98,8 @@ export type Realm = {
 export type Meta = {
     author_name: string;
     author_rewards: number;
+    author_filters: UserFilter;
+    viewer_blocked: boolean;
     realm_color: string;
 };
 


### PR DESCRIPTION
This change removes preloading of backend data (like all user names and some data of active realms) and loads this data on demand. This should remove the loading of hundreds of kilobytes of data when opening Taggr (and every 10m).

To compensate for the data missing on UI, posts are now extended with meta information and each user profile has a vector of realm ids they control.