### PR TITLE
feat: make minting and icp rewards mutually exclusive

### DIFF
--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -39,7 +39,7 @@ The fee is computed by multiplying `$excess_penalty` with the number of excessiv
 ## Rewards and Revenue Distribution
 
 -   During positive interactions, users can receive rewards from other users.
--   Rewards are converted to ICP and distributed to users every Friday.
+-   Rewards are converted to ICP and distributed to users every Friday if the user did not opt into mining mode.
 -   Earned rewards points are converted to ICP at the ratio `$credits_per_xdr` rewards / `$usd_per_xdr` USD.
 -   Additionally, users owning tokens and being active within the last `$voting_power_activity_weeks` weeks receive a share of $name's revenue proportionate to their token holdings.
 -   New rewards received by users with credit balance lower than `$credits_per_xdr` are automatically converted to credits and are used to top up the credit balance of these users.
@@ -127,7 +127,7 @@ This will make the supply keep an equilibrium around the maximal supply.
 ### Distribution of minted tokens
 
 All eligible users receive newly minted `$token_symbol` tokens on a weekly basis.
-Eligible are users without pending reports or reports closed within the last `$user_report_validity_days` and a positive reward balance.
+Eligible are users who opted for token minting, without pending reports or reports closed within the last `$user_report_validity_days`, and without a negative rewards balance.
 The amount of minted tokens is computed according to the following algorithm:
 
 1. For every user `U` who rewarded others, determine the maximal amount of donatable tokens capped by `U`'s `$token_symbol` balance divided by the minting ratio `R` (see below).

--- a/e2e/test2.spec.ts
+++ b/e2e/test2.spec.ts
@@ -269,10 +269,6 @@ test.describe("Regular users flow", () => {
     test("User profile", async () => {
         // Check data on alice's profile
         await page.getByRole("link", { name: "alice" }).first().click();
-        const rewards = Number(
-            await page.locator("div:has-text('REWARDS') > code").textContent(),
-        );
-        expect(rewards).toBeGreaterThanOrEqual(20);
 
         await page.locator("div:has-text('ACCOUNTING') > code").click();
         await expect(page.locator(".popup_body")).toHaveText(

--- a/e2e/test4.spec.ts
+++ b/e2e/test4.spec.ts
@@ -135,10 +135,6 @@ test.describe("Report and transfer to user", () => {
             .click({ delay: 3000 });
         // Wait because the UI waits for 4s before sending the command
         await page.waitForTimeout(6000);
-        await feedItem.getByRole("link", { name: "jane" }).first().click();
-        await expect(page.locator("div:has-text('REWARDS') > code")).toHaveText(
-            "20",
-        );
         exec("dfx canister call taggr weekly_chores");
         await page.waitForTimeout(1500);
     });

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1466,7 +1466,7 @@ impl State {
                     });
                 };
             }
-            mutate(|state| state.pending_nns_proposals.remove(&post_id));
+            mutate(|state| state.pending_nns_proposals.remove(&proposal_id));
         }
 
         // fetch new proposals
@@ -1602,6 +1602,12 @@ impl State {
             State::daily_chores(now).await;
             mutate(|state| {
                 state.last_daily_chores += DAY;
+                state.logger.debug(format!(
+                    "Pending NNS proposals: `{}`, pending polls: `{}`, migrations: `{}`.",
+                    state.pending_nns_proposals.len(),
+                    state.pending_polls.len(),
+                    state.migrations.len(),
+                ));
                 log_time(state, "Daily");
             });
         }

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -3102,10 +3102,11 @@ pub(crate) mod tests {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
 
-            for (i, rewards) in vec![125, -11, 0].into_iter().enumerate() {
+            for (i, rewards) in vec![125, -11, 0, 672].into_iter().enumerate() {
                 let id = create_user(state, pr(i as u8));
                 let user = state.users.get_mut(&id).unwrap();
                 user.change_rewards(rewards, "");
+                user.miner = i == 4;
             }
 
             let new_rewards = state.collect_new_rewards();
@@ -3122,6 +3123,10 @@ pub(crate) mod tests {
             let user = state.principal_to_user(pr(2)).unwrap();
             // no new rewards was collected
             assert!(!new_rewards.contains_key(&user.id));
+            assert_eq!(user.rewards(), 0);
+
+            let user = state.principal_to_user(pr(3)).unwrap();
+            // no new rewards was collected becasue the user is a miner
             assert_eq!(user.rewards(), 0);
         });
     }

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1241,11 +1241,7 @@ impl State {
         payouts
     }
 
-    async fn distribute_icp(
-        e8s_for_one_xdr: u64,
-        rewards: HashMap<UserId, u64>,
-        revenue: HashMap<UserId, u64>,
-    ) {
+    async fn distribute_icp() {
         let treasury_balance = match invoices::account_balance(invoices::main_account()).await {
             Ok(balance) => balance.e8s(),
             Err(err) => {
@@ -1258,89 +1254,8 @@ impl State {
                 return;
             }
         };
-        let debt = mutate(|state| {
-            let rewards = rewards
-                .iter()
-                .map(|(id, donations)| {
-                    (
-                        id,
-                        (*donations as f64 / CONFIG.credits_per_xdr as f64 * e8s_for_one_xdr as f64)
-                            as u64,
-                    )
-                })
-                .collect::<HashMap<_, _>>();
-            let total_payout =
-                rewards.values().copied().sum::<u64>() + revenue.values().copied().sum::<u64>();
-            if total_payout == 0 {
-                state.logger.info("No payouts to distribute...");
-                return 0;
-            }
-            // We stop distributions if the treasury balance falls below the minimum balance.
-            let minimal_treasury_balance = CONFIG.min_treasury_balance_xdrs * e8s_for_one_xdr;
-            if treasury_balance < total_payout || treasury_balance < minimal_treasury_balance {
-                state
-                    .logger
-                    .info("Treasury balance is too low; skipping the payouts...");
-                return 0;
-            }
-            let mut total_rewards = 0;
-            let mut total_revenue = 0;
-            let mut summary = Summary {
-                title: "Rewards report".into(),
-                description: Default::default(),
-                items: Vec::default(),
-            };
-            let mut items = Vec::default();
-            for user in state.users.values_mut() {
-                let mut user_revenue = revenue.get(&user.id).copied().unwrap_or_default();
-                let _ = user.top_up_credits_from_revenue(&mut user_revenue, e8s_for_one_xdr);
-                let user_reward = rewards.get(&user.id).copied().unwrap_or_default();
-                let e8s = match user_reward.checked_add(user_revenue) {
-                    Some(0) | None => continue,
-                    Some(value) => value,
-                };
-                user.treasury_e8s = match user.treasury_e8s.checked_add(e8s) {
-                    Some(0) | None => continue,
-                    Some(value) => value,
-                };
-                total_rewards += user_reward;
-                total_revenue += user_revenue;
-                items.push((e8s, user.name.clone()));
-                user.notify(format!(
-                    "You received `{}` ICP as rewards and `{}` ICP as revenue! 💸",
-                    display_tokens(user_reward, 8),
-                    display_tokens(user_revenue, 8)
-                ));
-            }
-            if state.burned_cycles > 0 {
-                state.spend(state.burned_cycles as Credits, "revenue distribution");
-                state.burned_cycles_total += state.burned_cycles as Credits;
-            }
-            state.total_rewards_shared += total_rewards;
-            state.total_revenue_shared += total_revenue;
-            let supply_of_active_users = state.active_voting_power(time());
-            let e8s_revenue_per_1k =
-                total_revenue / (supply_of_active_users / 1000 / token::base()).max(1);
-            state.last_revenues.push_back(e8s_revenue_per_1k);
-            while state.last_revenues.len() > 12 {
-                state.last_revenues.pop_front();
-            }
 
-            items.sort_by_cached_key(|(e8s, _)| Reverse(*e8s));
-            for (e8s, name) in &items {
-                summary
-                    .items
-                    .push(format!("`{}` to @{}", display_tokens(*e8s, 8), name));
-            }
-
-            summary.description = format!(
-                "Weekly pay out to users: `{}` ICP as rewards and `{}` ICP as revenue.",
-                display_tokens(total_rewards, 8),
-                display_tokens(total_revenue, 8)
-            );
-            state.distribution_reports.push(summary);
-            total_rewards + total_revenue
-        });
+        let debt = mutate(|state| state.assign_rewards_and_revenue(time(), treasury_balance));
 
         if let Err(err) = canisters::icrc_transfer(
             MAINNET_LEDGER_CANISTER_ID,
@@ -1359,6 +1274,96 @@ impl State {
                 ))
             });
         }
+    }
+
+    fn assign_rewards_and_revenue(&mut self, now: Time, treasury_balance: u64) -> u64 {
+        let (rewards, revenue, e8s_for_one_xdr) = (
+            self.collect_new_rewards(),
+            self.collect_revenue(now, self.e8s_for_one_xdr),
+            self.e8s_for_one_xdr,
+        );
+        let rewards = rewards
+            .iter()
+            .map(|(id, donations)| {
+                (
+                    id,
+                    (*donations as f64 / CONFIG.credits_per_xdr as f64 * e8s_for_one_xdr as f64)
+                        as u64,
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        let total_payout =
+            rewards.values().copied().sum::<u64>() + revenue.values().copied().sum::<u64>();
+        if total_payout == 0 {
+            self.logger.info("No payouts to distribute...");
+            return 0;
+        }
+        // We stop distributions if the treasury balance falls below the minimum balance.
+        let minimal_treasury_balance = CONFIG.min_treasury_balance_xdrs * e8s_for_one_xdr;
+        if treasury_balance < total_payout || treasury_balance < minimal_treasury_balance {
+            self.logger
+                .info("Treasury balance is too low; skipping the payouts...");
+            return 0;
+        }
+        let mut total_rewards = 0;
+        let mut total_revenue = 0;
+        let mut summary = Summary {
+            title: "Rewards report".into(),
+            description: Default::default(),
+            items: Vec::default(),
+        };
+        let mut items = Vec::default();
+        for user in self.users.values_mut() {
+            let mut user_revenue = revenue.get(&user.id).copied().unwrap_or_default();
+            let _ = user.top_up_credits_from_revenue(&mut user_revenue, e8s_for_one_xdr);
+            let user_reward = rewards.get(&user.id).copied().unwrap_or_default();
+            let e8s = match user_reward.checked_add(user_revenue) {
+                Some(0) | None => continue,
+                Some(value) => value,
+            };
+
+            user.treasury_e8s = match user.treasury_e8s.checked_add(e8s) {
+                Some(0) | None => continue,
+                Some(value) => value,
+            };
+            total_rewards += user_reward;
+            total_revenue += user_revenue;
+            items.push((e8s, user.name.clone()));
+            user.notify(format!(
+                "You received `{}` ICP as rewards and `{}` ICP as revenue! 💸",
+                display_tokens(user_reward, 8),
+                display_tokens(user_revenue, 8)
+            ));
+        }
+        if self.burned_cycles > 0 {
+            self.spend(self.burned_cycles as Credits, "revenue distribution");
+            self.burned_cycles_total += self.burned_cycles as Credits;
+        }
+        self.total_rewards_shared += total_rewards;
+        self.total_revenue_shared += total_revenue;
+        let supply_of_active_users = self.active_voting_power(time());
+        let e8s_revenue_per_1k =
+            total_revenue / (supply_of_active_users / 1000 / token::base()).max(1);
+        self.last_revenues.push_back(e8s_revenue_per_1k);
+        while self.last_revenues.len() > 12 {
+            self.last_revenues.pop_front();
+        }
+
+        items.sort_by_cached_key(|(e8s, _)| Reverse(*e8s));
+        for (e8s, name) in &items {
+            summary
+                .items
+                .push(format!("`{}` to @{}", display_tokens(*e8s, 8), name));
+        }
+
+        summary.description = format!(
+            "Weekly pay out to users: `{}` ICP as rewards and `{}` ICP as revenue.",
+            display_tokens(total_rewards, 8),
+            display_tokens(total_revenue, 8)
+        );
+        self.distribution_reports.push(summary);
+
+        total_rewards + total_revenue
     }
 
     fn conclude_polls(&mut self, now: u64) {
@@ -1620,17 +1625,12 @@ impl State {
 
         // We only mint and distribute if no open proposals exists
         if read(|state| state.proposals.iter().all(|p| p.status != Status::Open)) {
-            let (rewards, revenues, e8s_for_one_xdr) = mutate(|state| {
+            mutate(|state| {
                 state.minting_mode = true;
                 state.mint();
                 state.minting_mode = false;
-                (
-                    state.collect_new_rewards(),
-                    state.collect_revenue(time(), state.e8s_for_one_xdr),
-                    state.e8s_for_one_xdr,
-                )
             });
-            State::distribute_icp(e8s_for_one_xdr, rewards, revenues).await;
+            State::distribute_icp().await;
             mutate(|state| {
                 for summary in &state.distribution_reports {
                     state.logger.info(format!(
@@ -3175,7 +3175,7 @@ pub(crate) mod tests {
             cell.replace(Default::default());
             let state = &mut *cell.borrow_mut();
 
-            let rewards_insert = |state: &mut State, donor_id, user_id, rewards| {
+            let insert_rewards = |state: &mut State, donor_id, user_id, rewards| {
                 state
                     .users
                     .get_mut(&donor_id)
@@ -3190,7 +3190,7 @@ pub(crate) mod tests {
                 insert_balance(state, pr(i), (((i + 1) as u64) << 2) * 10000);
                 for j in 0..5 {
                     if i != j {
-                        rewards_insert(state, i as u64, j as u64, ((j + 1) * (i + 1)) as u64 * 100);
+                        insert_rewards(state, i as u64, j as u64, ((j + 1) * (i + 1)) as u64 * 100);
                     }
                 }
             }
@@ -3234,8 +3234,8 @@ pub(crate) mod tests {
             assert_eq!(state.minting_ratio(), 2);
 
             // Test circuit breaking
-            rewards_insert(state, 4, 3, 301);
-            rewards_insert(state, 4, 4, 60_000);
+            insert_rewards(state, 4, 3, 301);
+            insert_rewards(state, 4, 4, 60_000);
 
             // Tokens were not minted to to circuit breaking
             state.minting_mode = true;
@@ -4725,6 +4725,85 @@ pub(crate) mod tests {
             let user = state.users.get(&id).unwrap();
             assert_eq!(user.credits(), prev_balance - 222);
             assert_eq!(read(|state| state.burned_cycles), prev_revenue);
+        });
+    }
+
+    #[test]
+    fn test_icp_distribution() {
+        mutate(|state| {
+            let now = WEEK * 4;
+            // Create 10 users with balances and rewards
+            for i in 0..10 {
+                create_user(state, pr(i));
+                let user = state.principal_to_user_mut(pr(i)).unwrap();
+                assert!(user.miner);
+                user.last_activity = now;
+                if i > 0 {
+                    user.change_rewards(300, "");
+                    insert_balance(state, pr(i), 300 * token::base());
+                }
+            }
+
+            // Make user pr(3) have a low credits balance
+            state
+                .principal_to_user_mut(pr(3))
+                .unwrap()
+                .change_credits(900, CreditsDelta::Minus, "")
+                .unwrap();
+
+            // Make user pr(4) have a pending report
+            state.principal_to_user_mut(pr(4)).unwrap().report = Some(Default::default());
+
+            // Make user pr(5) inactive
+            let user = state.principal_to_user_mut(pr(5)).unwrap();
+            user.last_activity = 0;
+            user.change_rewards(-user.rewards(), "");
+
+            // Make user pr(6) have negative rewards
+            state
+                .principal_to_user_mut(pr(6))
+                .unwrap()
+                .change_rewards(-1000, "");
+
+            // Make user pr(7) non-miner
+            state.principal_to_user_mut(pr(7)).unwrap().miner = false;
+
+            // Assume the revenue was 1M credits
+            state.burned_cycles = 1_000_000;
+
+            // For simplicity assume 100 e8s for 1 xdr
+            state.e8s_for_one_xdr = 100;
+
+            let payout = state.assign_rewards_and_revenue(now, 100000000);
+
+            // Payout will be the amount of burned cycles + rewards of miners,
+            // divided by the XDR rate
+            assert_eq!(payout, 100330);
+            assert_eq!(
+                payout,
+                state.users.values().map(|u| u.treasury_e8s).sum::<u64>()
+            );
+
+            // pr(0) had 0 rewards and 0 tokens
+            assert_eq!(state.principal_to_user(pr(0)).unwrap().treasury_e8s, 0);
+            // pr(1) had 100 rewards and 10000 tokens
+            assert_eq!(state.principal_to_user(pr(1)).unwrap().treasury_e8s, 12545);
+            // pr(2) had 200 rewards and 20000 tokens
+            assert_eq!(state.principal_to_user(pr(2)).unwrap().treasury_e8s, 12545);
+            // pr(3) had 300 rewards and 30000 tokens, but also a low credit balance
+            let user = state.principal_to_user(pr(3)).unwrap();
+            assert_eq!(user.credits(), 1000);
+            assert_eq!(user.treasury_e8s, 12455);
+            // pr(4) had a pending report (no effect on VP => revenue ICP)
+            assert_eq!(state.principal_to_user(pr(4)).unwrap().treasury_e8s, 12545);
+            // pr(5) is inactive and skipped for revenue
+            assert_eq!(state.principal_to_user(pr(5)).unwrap().treasury_e8s, 0);
+            // pr(6) has negative rewards balance (no effect on VP => revenue ICP)
+            assert_eq!(state.principal_to_user(pr(6)).unwrap().treasury_e8s, 12545);
+            // pr(7) is not miner, so he gets the highest rewards
+            assert_eq!(state.principal_to_user(pr(7)).unwrap().treasury_e8s, 12605);
+            assert_eq!(state.principal_to_user(pr(8)).unwrap().treasury_e8s, 12545);
+            assert_eq!(state.principal_to_user(pr(9)).unwrap().treasury_e8s, 12545);
         });
     }
 }

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1090,13 +1090,11 @@ impl State {
                 .or_insert(tokens);
         }
 
-        tokens_to_mint.retain(|user_id, balance| {
-            *balance > 0
-                && self
-                    .users
-                    .get(user_id)
-                    .map(|user| user.eligible_for_minting())
-                    .unwrap_or_default()
+        tokens_to_mint.retain(|user_id, _| {
+            self.users
+                .get(user_id)
+                .map(|user| user.eligible_for_minting())
+                .unwrap_or_default()
         });
 
         tokens_to_mint

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -314,9 +314,7 @@ impl User {
             state
                 .last_posts(None, offset, self.timestamp, false)
                 .filter(move |post| {
-                    !post.is_deleted()
-                        && post.parent.is_none()
-                        && !post.matches_filters(&self.filters)
+                    !post.matches_filters(&self.filters)
                         && post
                             .realm
                             .as_ref()

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -593,13 +593,18 @@ impl User {
 
         let total = shares.iter().map(|(_, share)| share).sum::<u64>();
 
-        Box::new(shares.into_iter().map(move |(user_id, share)| {
-            (
-                user_id,
-                spendable_tokens_per_user
-                    .min((share as f32 / total as f32 * spendable_tokens as f32) as Token),
-            )
-        }))
+        Box::new(
+            shares
+                .into_iter()
+                .map(move |(user_id, share)| {
+                    (
+                        user_id,
+                        spendable_tokens_per_user
+                            .min((share as f32 / total as f32 * spendable_tokens as f32) as Token),
+                    )
+                })
+                .filter(|(_, balance)| balance > &0),
+        )
     }
 }
 

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -79,19 +79,9 @@ fn post_upgrade() {
 }
 
 fn sync_post_upgrade_fixtures() {
-    // Fill the root posts index.
     mutate(|state| {
-        state.root_posts_index = (0..state.next_post_id)
-            .filter_map(|id| Post::get(state, &id))
-            .filter_map(|post| post.parent.is_none().then_some(post.id))
-            .collect()
-    });
-
-    // Remove user report according to DAO poll: https://6qfxa-ryaaa-aaaai-qbhsq-cai.icp0.io/#/post/621615
-    mutate(|state| {
-        if let Some(zikhas) = state.users.get_mut(&789) {
-            assert_eq!(zikhas.name, "Zikhas");
-            zikhas.report.take();
+        for user in state.users.values_mut() {
+            user.miner = true;
         }
     })
 }

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -220,11 +220,12 @@ fn confirm_principal_change() {
 
 #[export_name = "canister_update update_user"]
 fn update_user() {
-    let (new_name, about, principals, filter, governance, show_posts_in_realms): (
+    let (new_name, about, principals, filter, governance, miner, show_posts_in_realms): (
         String,
         String,
         Vec<String>,
         UserFilter,
+        bool,
         bool,
         bool,
     ) = parse(&arg_data_raw());
@@ -235,6 +236,7 @@ fn update_user() {
         principals,
         filter,
         governance,
+        miner,
         show_posts_in_realms,
     ))
 }

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -80,6 +80,19 @@ fn post_upgrade() {
 
 fn sync_post_upgrade_fixtures() {
     mutate(|state| {
+        // Fill the root posts index.
+        state.root_posts_index = (0..state.next_post_id)
+            .filter_map(|id| Post::get(state, &id))
+            .filter_map(|post| post.parent.is_none().then_some(post.id))
+            .collect();
+
+        // Remove user report according to DAO poll: https://6qfxa-ryaaa-aaaai-qbhsq-cai.icp0.io/#/post/621615
+        if let Some(zikhas) = state.users.get_mut(&789) {
+            assert_eq!(zikhas.name, "Zikhas");
+            zikhas.report.take();
+        }
+
+        // Init all users as minters
         for user in state.users.values_mut() {
             user.miner = true;
         }

--- a/src/frontend/src/profile.tsx
+++ b/src/frontend/src/profile.tsx
@@ -411,12 +411,14 @@ export const UserInfo = ({
                         </a>
                     </div>
                 )}
-                <div className="db_cell">
-                    REWARDS
-                    <code className="accent">
-                        {profile.rewards.toLocaleString()}
-                    </code>
-                </div>
+                {(!profile.miner || profile.rewards < 0) && (
+                    <div className="db_cell">
+                        REWARDS
+                        <code className="accent">
+                            {profile.rewards.toLocaleString()}
+                        </code>
+                    </div>
+                )}
                 <div className="db_cell">
                     JOINED
                     <span>{`${timeAgo(profile.timestamp)}`}</span>

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -152,15 +152,18 @@ export const Settings = ({ invite }: { invite?: string }) => {
                 {user && (
                     <>
                         <div className="bottom_half_spaced">
-                            Participate in token minting
+                            Token minting and rewards:
                         </div>
                         <select
                             value={miner}
                             className="bottom_spaced"
                             onChange={(event) => setMiner(event.target.value)}
                         >
-                            <option value="true">YES</option>
-                            <option value="false">NO</option>
+                            <option value="true">
+                                Mint {window.backendCache.config.token_symbol}{" "}
+                                tokens
+                            </option>
+                            <option value="false">Receive ICP rewards</option>
                         </select>
                         <div className="bottom_half_spaced">
                             Participate in governance

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -17,6 +17,7 @@ export const Settings = ({ invite }: { invite?: string }) => {
     const [timer, setTimer] = React.useState<any>();
     const [uiRefresh, setUIRefresh] = React.useState(false);
     const [governance, setGovernance] = React.useState("true");
+    const [miner, setMiner] = React.useState("true");
     const [showPostsInRealms, setShowPostsInRealms] = React.useState("true");
     const [userFilter, setUserFilter] = React.useState<UserFilter>({
         safe: false,
@@ -33,6 +34,7 @@ export const Settings = ({ invite }: { invite?: string }) => {
         setControllers(user.controllers.join("\n"));
         setSettings(user.settings);
         setGovernance(user.governance.toString());
+        setMiner(user.miner.toString());
         setShowPostsInRealms(user.show_posts_in_realms.toString());
         setUserFilter(user.filters.noise);
     };
@@ -102,6 +104,7 @@ export const Settings = ({ invite }: { invite?: string }) => {
                 principal_ids,
                 userFilter,
                 governance == "true",
+                miner == "true",
                 showPostsInRealms == "true",
             ),
             window.api.call<any>("update_user_settings", settings),
@@ -148,6 +151,17 @@ export const Settings = ({ invite }: { invite?: string }) => {
                 />
                 {user && (
                     <>
+                        <div className="bottom_half_spaced">
+                            Participate in token minting
+                        </div>
+                        <select
+                            value={miner}
+                            className="bottom_spaced"
+                            onChange={(event) => setMiner(event.target.value)}
+                        >
+                            <option value="true">YES</option>
+                            <option value="false">NO</option>
+                        </select>
                         <div className="bottom_half_spaced">
                             Participate in governance
                         </div>

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -190,6 +190,7 @@ export type User = {
     bookmarks: number[];
     last_activity: BigInt;
     governance: boolean;
+    miner: boolean;
     settings: {
         [key: string]: string;
     };


### PR DESCRIPTION
Implementation of https://taggr.wtf/#/post/670617:

- Every user can switch to the mining mode
- In mining mode no rewards for reactions can be received and paid out
- Only in mining mode can a user mine new TAGGR.
- No cycles top up is possible anymore.