### PR TITLE
Release

### DIFF
--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -145,6 +145,7 @@ The minting ratio `R` is algorithmically computed by $name.
 It starts at `1:1` and remains at this level until `10%` of supply is minted.
 Then the ratio decreases to `2:1` for the next `10%`, further decreasing to `4:1`, and so on.
 Hence, the last `10%` of the supply will be minted at a ratio of `512:1`.
+Additionally, the DAO can increase the ratio by setting a difficulty amplification factor if the minting speed becomes misaligned with DAO's expectations.
 
 ### Team Tokens
 

--- a/src/backend/env/config.rs
+++ b/src/backend/env/config.rs
@@ -23,6 +23,11 @@ pub struct Config {
     pub token_symbol: &'static str,
     pub maximum_supply: Token,
 
+    // This is a custom difficulty adjustment that can be set by the DAO in emergency cases
+    // when the speed of minting does not meet DAO's expectations. Currently, we consider this as a
+    // temporary measure to slow down the minting until the DAO agrees on a better approach.
+    pub difficulty_amplification: u64,
+
     pub max_age_hot_post_days: u64,
 
     pub downvote_counting_period_days: u64,
@@ -186,6 +191,11 @@ pub const CONFIG: &Config = &Config {
     minting_threshold_percentage: 5,
 
     active_user_share_for_minting_promille: 10,
+
+    #[cfg(any(test, feature = "dev"))]
+    difficulty_amplification: 1,
+    #[cfg(not(any(test, feature = "dev")))]
+    difficulty_amplification: 6,
 
     max_age_hot_post_days: 2,
 

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -2205,9 +2205,13 @@ impl State {
         let mut active_users = 0;
         let mut bots = Vec::new();
         let mut credits = 0;
+        let mut speculative_revenue = 0;
         for user in self.users.values() {
             if user.stalwart {
                 stalwarts.push(user);
+            }
+            if user.miner {
+                speculative_revenue += user.rewards().max(0);
             }
             if now < user.last_activity + CONFIG.online_activity_minutes {
                 users_online += 1;
@@ -2262,7 +2266,7 @@ impl State {
             posts,
             comments: Post::count(self) - posts,
             credits,
-            burned_credits: self.burned_cycles,
+            burned_credits: self.burned_cycles + speculative_revenue,
             total_revenue_shared: self.total_revenue_shared,
             total_rewards_shared: self.total_rewards_shared,
             account: invoices::main_account().to_string(),

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1058,7 +1058,7 @@ impl State {
     pub fn minting_ratio(&self) -> u64 {
         let circulating_supply: Token = self.balances.values().sum();
         let factor = (circulating_supply as f64 / CONFIG.maximum_supply as f64 * 10.0) as u64;
-        1 << factor
+        (1 << factor) * CONFIG.difficulty_amplification
     }
 
     pub fn tokens_to_mint(&self) -> BTreeMap<UserId, Token> {

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -204,8 +204,12 @@ pub struct State {
     #[serde(skip)]
     pub backup_exists: bool,
 
+    // TODO: delete
     #[serde(skip)]
     pub last_archive: u64,
+
+    #[serde(default)]
+    pub minting_power: HashMap<Principal, Token>,
 }
 
 #[derive(Default, Deserialize, Serialize)]
@@ -2122,6 +2126,12 @@ impl State {
             .remove(&old_principal)
             .ok_or("no principal found")?;
         self.principals.insert(new_principal, user_id);
+        let minting_power = self
+            .minting_power
+            .get(&old_principal)
+            .copied()
+            .unwrap_or_default();
+        self.minting_power.insert(new_principal, minting_power);
         let user = self.users.get_mut(&user_id).expect("no user found");
         assert_eq!(user.principal, old_principal);
         user.principal = new_principal;

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -2874,7 +2874,6 @@ pub(crate) mod tests {
         token::mint(state, account(principal), amount);
         state.minting_mode = false;
         if let Some(user) = state.principal_to_user_mut(principal) {
-            user.balance = amount;
             user.change_rewards((amount / token::base()) as i64, "");
         }
     }

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -72,7 +72,6 @@ pub struct Stats {
     credits: Credits,
     canister_cycle_balance: u64,
     burned_credits: i64,
-    burned_credits_total: Credits,
     total_revenue_shared: u64,
     total_rewards_shared: u64,
     posts: usize,
@@ -133,6 +132,8 @@ pub struct Summary {
 #[derive(Default, Serialize, Deserialize)]
 pub struct State {
     pub burned_cycles: i64,
+    // TODO: delete
+    #[serde(skip)]
     pub burned_cycles_total: Credits,
     pub posts: BTreeMap<PostId, Post>,
     pub users: BTreeMap<UserId, User>,
@@ -183,10 +184,6 @@ pub struct State {
     pending_nns_proposals: BTreeMap<u64, PostId>,
 
     pub last_nns_proposal: u64,
-
-    // TODO: delete
-    #[serde(skip)]
-    pub root_posts: usize,
 
     #[serde(default)]
     pub root_posts_index: Vec<PostId>,
@@ -1335,7 +1332,6 @@ impl State {
         }
         if self.burned_cycles > 0 {
             self.spend(self.burned_cycles as Credits, "revenue distribution");
-            self.burned_cycles_total += self.burned_cycles as Credits;
         }
         self.total_rewards_shared += total_rewards;
         self.total_revenue_shared += total_revenue;
@@ -2267,7 +2263,6 @@ impl State {
             comments: Post::count(self) - posts,
             credits,
             burned_credits: self.burned_cycles,
-            burned_credits_total: self.burned_cycles_total,
             total_revenue_shared: self.total_revenue_shared,
             total_rewards_shared: self.total_rewards_shared,
             account: invoices::main_account().to_string(),

--- a/src/backend/env/token.rs
+++ b/src/backend/env/token.rs
@@ -286,13 +286,14 @@ pub fn transfer(
         } else {
             state.balances.insert(from.clone(), resulting_balance);
         }
-        update_user_balance(state, from.owner, resulting_balance as Token);
+        update_user_balance(state, from.owner, resulting_balance as Token, None);
     }
     if to.owner != Principal::anonymous() {
         let recipient_balance = state.balances.remove(&to).unwrap_or_default();
         let updated_balance = recipient_balance.saturating_add(amount as Token);
         state.balances.insert(to.clone(), updated_balance);
-        update_user_balance(state, to.owner, updated_balance as Token);
+        let minted_tokens = (from.owner == Principal::anonymous()).then_some(amount as Token);
+        update_user_balance(state, to.owner, updated_balance as Token, minted_tokens);
     }
 
     state.ledger.push(Transaction {
@@ -306,12 +307,22 @@ pub fn transfer(
     Ok(state.ledger.len().saturating_sub(1) as u128)
 }
 
-fn update_user_balance(state: &mut State, principal: Principal, balance: Token) {
+fn update_user_balance(
+    state: &mut State,
+    principal: Principal,
+    balance: Token,
+    minted_tokens: Option<Token>,
+) {
     if let Some(user) = state.principal_to_user_mut(principal) {
         if user.principal == principal {
             user.balance = balance
         } else if user.cold_wallet == Some(principal) {
             user.cold_balance = balance
+        } else {
+            unreachable!("unidentifiable principal")
+        }
+        if let Some(tokens) = minted_tokens {
+            user.minted += tokens;
         }
     }
 }

--- a/src/backend/env/token.rs
+++ b/src/backend/env/token.rs
@@ -322,7 +322,11 @@ fn update_user_balance(
             unreachable!("unidentifiable principal")
         }
         if let Some(tokens) = minted_tokens {
-            user.minted += tokens;
+            state
+                .minting_power
+                .entry(principal)
+                .and_modify(|balance| *balance += tokens)
+                .or_insert(tokens);
         }
     }
 }

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -110,8 +110,6 @@ pub struct User {
     pub show_posts_in_realms: bool,
     pub posts: Vec<PostId>,
     pub miner: bool,
-    #[serde(default)]
-    pub minted: Token,
 }
 
 impl User {
@@ -185,7 +183,6 @@ impl User {
             miner: true,
             downvotes: Default::default(),
             show_posts_in_realms: true,
-            minted: 0,
         }
     }
 
@@ -554,8 +551,13 @@ impl User {
             // During the bootstrap period, use karma and not balances
             donated_karma
         } else {
+            let minting_power = state
+                .minting_power
+                .get(&self.principal)
+                .copied()
+                .unwrap_or_default();
             self.total_balance()
-                .min(self.minted)
+                .min(minting_power)
                 .min(donated_karma)
                 .min(CONFIG.max_spendable_tokens)
         } / ratio;

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -109,8 +109,9 @@ pub struct User {
     pub downvotes: BTreeMap<UserId, Time>,
     pub show_posts_in_realms: bool,
     pub posts: Vec<PostId>,
-    #[serde(default)]
     pub miner: bool,
+    #[serde(default)]
+    pub minted: Token,
 }
 
 impl User {
@@ -184,6 +185,7 @@ impl User {
             miner: true,
             downvotes: Default::default(),
             show_posts_in_realms: true,
+            minted: 0,
         }
     }
 
@@ -553,6 +555,7 @@ impl User {
             donated_karma
         } else {
             self.total_balance()
+                .min(self.minted)
                 .min(donated_karma)
                 .min(CONFIG.max_spendable_tokens)
         } / ratio;
@@ -706,6 +709,118 @@ mod tests {
             balance: 1,
             num_followers: 0
         }));
+    }
+
+    #[test]
+    fn test_minted_tokens_cap() {
+        let state = &mut State::default();
+        let donor_id = create_user(state, pr(0));
+        let u1 = create_user(state, pr(1));
+        let u2 = create_user(state, pr(2));
+        let u3 = create_user(state, pr(3));
+        insert_balance(state, pr(0), 6000); // spendable tokens
+        assert_eq!(state.minting_ratio(), 1);
+
+        let donor = state.users.get_mut(&donor_id).unwrap();
+        donor.karma_donations.insert(u1, 330);
+        donor.karma_donations.insert(u2, 660);
+        donor.karma_donations.insert(u3, 990);
+        // Donate
+        let mintable_tokens = state
+            .users
+            .get(&donor_id)
+            .unwrap()
+            .mintable_tokens(state, 1, false)
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(mintable_tokens.len(), 3);
+
+        let donor = state.users.get_mut(&donor_id).unwrap();
+
+        // Assume the donor minted 6k tokens
+        assert_eq!(donor.minted, 6000);
+
+        // Simulate a tx to the cold wallet
+        donor.balance -= 5500;
+        donor.cold_balance += 5500;
+
+        // Ensure we mint as many tokens as before
+        assert_eq!(
+            mintable_tokens,
+            state
+                .users
+                .get(&donor_id)
+                .unwrap()
+                .mintable_tokens(state, 1, false)
+                .collect::<BTreeMap<_, _>>()
+        );
+
+        // Simulate an outflow of 50% from the cold wallet
+        let donor = state.users.get_mut(&donor_id).unwrap();
+        donor.cold_balance -= 3000;
+        let mintable_tokens_after_outflow = state
+            .users
+            .get(&donor_id)
+            .unwrap()
+            .mintable_tokens(state, 1, false)
+            .collect::<BTreeMap<_, _>>();
+
+        // Rewards have halved
+        for id in &[u1, u2, u3] {
+            assert_eq!(
+                *mintable_tokens.get(id).unwrap(),
+                mintable_tokens_after_outflow.get(id).unwrap() * 2,
+            );
+        }
+
+        // Simulate an inflow of 100%
+        let donor = state.users.get_mut(&donor_id).unwrap();
+        donor.balance += 6000;
+        let mintable_tokens_after_inflow = state
+            .users
+            .get(&donor_id)
+            .unwrap()
+            .mintable_tokens(state, 1, false)
+            .collect::<BTreeMap<_, _>>();
+
+        // Rewards are back to the minting levels, but not more!
+        for id in &[u1, u2, u3] {
+            assert_eq!(
+                mintable_tokens.get(id).unwrap(),
+                mintable_tokens_after_inflow.get(id).unwrap(),
+            );
+        }
+
+        // Simulate an outflow from all wallets
+        let donor = state.users.get_mut(&donor_id).unwrap();
+        donor.balance = 0;
+        donor.cold_balance = 0;
+        let mintable_tokens_after_selloff = state
+            .users
+            .get(&donor_id)
+            .unwrap()
+            .mintable_tokens(state, 1, false)
+            .collect::<BTreeMap<_, _>>();
+        assert!(mintable_tokens_after_selloff.is_empty());
+
+        // Simulate an inflow of 10% of the original minted balance
+        let donor = state.users.get_mut(&donor_id).unwrap();
+        assert_eq!(donor.balance, 0);
+        assert_eq!(donor.cold_balance, 0);
+        donor.balance += 600;
+        let mintable_tokens_after_buyback = state
+            .users
+            .get(&donor_id)
+            .unwrap()
+            .mintable_tokens(state, 1, false)
+            .collect::<BTreeMap<_, _>>();
+
+        // Rewards are back to the minting levels, but not more!
+        for id in &[u1, u2, u3] {
+            assert_eq!(
+                mintable_tokens.get(id).unwrap() / 10,
+                *mintable_tokens_after_buyback.get(id).unwrap(),
+            );
+        }
     }
 
     #[test]

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -378,10 +378,11 @@ fn hot_realm_posts() {
             state
                 .hot_posts(
                     optional(realm),
-                    page,
                     offset,
                     Some(&|post: &Post| post.realm.is_some()),
                 )
+                .skip(page * CONFIG.feed_page_size)
+                .take(CONFIG.feed_page_size)
                 .collect::<Vec<_>>(),
         )
     });
@@ -406,8 +407,10 @@ fn hot_posts() {
         let user = state.principal_to_user(caller());
         reply(
             state
-                .hot_posts(optional(realm), page, offset, None)
+                .hot_posts(optional(realm), offset, None)
                 .filter(|post| !filtered || personal_filter(state, user, post))
+                .skip(page * CONFIG.feed_page_size)
+                .take(CONFIG.feed_page_size)
                 .collect::<Vec<_>>(),
         )
     });
@@ -420,8 +423,10 @@ fn realms_posts() {
         let user = state.principal_to_user(caller());
         reply(
             state
-                .realms_posts(caller(), page, offset)
+                .realms_posts(caller(), offset)
                 .filter(|post| personal_filter(state, user, post))
+                .skip(page * CONFIG.feed_page_size)
+                .take(CONFIG.feed_page_size)
                 .collect::<Vec<_>>(),
         )
     });

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -78,26 +78,7 @@ fn post_upgrade() {
     )
 }
 
-fn sync_post_upgrade_fixtures() {
-    mutate(|state| {
-        // Fill the root posts index.
-        state.root_posts_index = (0..state.next_post_id)
-            .filter_map(|id| Post::get(state, &id))
-            .filter_map(|post| post.parent.is_none().then_some(post.id))
-            .collect();
-
-        // Remove user report according to DAO poll: https://6qfxa-ryaaa-aaaai-qbhsq-cai.icp0.io/#/post/621615
-        if let Some(zikhas) = state.users.get_mut(&789) {
-            assert_eq!(zikhas.name, "Zikhas");
-            zikhas.report.take();
-        }
-
-        // Init all users as minters
-        for user in state.users.values_mut() {
-            user.miner = true;
-        }
-    })
-}
+fn sync_post_upgrade_fixtures() {}
 
 async fn async_post_upgrade_fixtures() {}
 

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -89,8 +89,13 @@ fn sync_post_upgrade_fixtures() {
             .collect::<Vec<_>>()
             .into_iter()
         {
-            if let Some(user) = state.principal_to_user_mut(owner) {
-                user.minted += amount;
+            // We only track it for actually used principals
+            if state.principal_to_user(owner).is_some() {
+                state
+                    .minting_power
+                    .entry(owner)
+                    .and_modify(|b| *b += amount)
+                    .or_insert(amount);
             }
         }
     })

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -78,7 +78,23 @@ fn post_upgrade() {
     )
 }
 
-fn sync_post_upgrade_fixtures() {}
+fn sync_post_upgrade_fixtures() {
+    // compute minted amount of tokens for all users
+    mutate(|state| {
+        for (owner, amount) in state
+            .ledger
+            .iter()
+            .filter(|tx| tx.from.owner == Principal::anonymous())
+            .map(|tx| (tx.to.owner, tx.amount))
+            .collect::<Vec<_>>()
+            .into_iter()
+        {
+            if let Some(user) = state.principal_to_user_mut(owner) {
+                user.minted += amount;
+            }
+        }
+    })
+}
 
 async fn async_post_upgrade_fixtures() {}
 

--- a/src/frontend/src/poll.tsx
+++ b/src/frontend/src/poll.tsx
@@ -182,7 +182,12 @@ export const PollView = ({
                     )}
                 </span>
             )}
-            {expired && (
+            {expired && Object.keys(data.weighted_by_tokens).length == 0 && (
+                <span className="top_spaced small_text text_centered inactive">
+                    RESULTS ARE PENDING
+                </span>
+            )}
+            {expired && Object.keys(data.weighted_by_tokens).length > 0 && (
                 <>
                     <h4 className="top_framed" style={{ paddingTop: "1em" }}>
                         RESULTS BY VOTING POWER
@@ -190,6 +195,7 @@ export const PollView = ({
                     {Object.entries(data.weighted_by_tokens).map(
                         ([index, vp]: [string, number]) => (
                             <Content
+                                key={index}
                                 post={false}
                                 value={
                                     data.options[Number(index)] +

--- a/src/frontend/src/poll.tsx
+++ b/src/frontend/src/poll.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ButtonWithLoading, userList } from "./common";
+import { ButtonWithLoading, token, userList } from "./common";
 import { Content } from "./content";
 import { Poll, PostId } from "./types";
 
@@ -41,12 +41,6 @@ export const PollView = ({
         poll.deadline - createdHoursAgo >
             window.backendCache.config.poll_revote_deadline_hours;
     const showVoting = !isNaN(user_id) && !voted && !expired;
-    const keyWithMaxVal = (obj: { [key: number]: number }) =>
-        Object.keys(obj).reduce(
-            ([maxKey, maxVal]: any, key: any) =>
-                obj[key] > maxVal ? [key, obj[key]] : [maxKey, maxVal],
-            [null, 0],
-        )[0];
 
     return (
         <div className="column_container post_extension" data-meta="skipClicks">
@@ -189,12 +183,22 @@ export const PollView = ({
                 </span>
             )}
             {expired && (
-                <Content
-                    post={false}
-                    value={`RESULT BY VP: **${
-                        data.options[keyWithMaxVal(data.weighted_by_tokens)]
-                    }**`}
-                />
+                <>
+                    <h4 className="top_framed" style={{ paddingTop: "1em" }}>
+                        RESULTS BY VOTING POWER
+                    </h4>
+                    {Object.entries(data.weighted_by_tokens).map(
+                        ([index, vp]: [string, number]) => (
+                            <Content
+                                post={false}
+                                value={
+                                    data.options[Number(index)] +
+                                    `: \`${token(vp)}\``
+                                }
+                            />
+                        ),
+                    )}
+                </>
             )}
         </div>
     );

--- a/src/frontend/src/tokens.tsx
+++ b/src/frontend/src/tokens.tsx
@@ -62,6 +62,9 @@ export const Tokens = () => {
     }, []);
 
     const mintedSupply = balances.reduce((acc, balance) => acc + balance[1], 0);
+    const top100Supply = balances
+        .slice(0, 100)
+        .reduce((acc, balance) => acc + balance[1], 0);
     const heldByUsers = balances.reduce(
         (acc, [_0, balance, userId]) => (userId == null ? acc : acc + balance),
         0,
@@ -188,13 +191,13 @@ export const Tokens = () => {
                     </div>
                 </div>
                 <h2>Top 100 token holders</h2>
-                <div className="row_container bottom_spaced">
+                <div className="bottom_spaced" style={{ display: "flex" }}>
                     {balances.slice(0, 100).map((b) => (
                         <div
                             key={b[0].owner.toString()}
                             style={{
                                 height: "5em",
-                                width: percentage(b[1], mintedSupply),
+                                width: percentage(b[1], top100Supply),
                                 background:
                                     holder == b[2]
                                         ? "black"

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -266,7 +266,6 @@ declare global {
                 users_online: number;
                 credits: number;
                 burned_credits: BigInt;
-                burned_credits_total: BigInt;
                 circulating_supply: number;
                 total_rewards_shared: BigInt;
                 total_revenue_shared: BigInt;


### PR DESCRIPTION
- Fix: display speculative revenue on the dashboard (like the speculative token mint but for ICP)
- Improvement: Display VP on all options of a poll
- Feature: cap donatable tokens by the minted account according to the [DAO poll](https://6qfxa-ryaaa-aaaai-qbhsq-cai.icp0.io/#/post/803089).
- Feature: introduce a difficulty adjustment factor that will make the minting target `11` years according to the result of the [DAO poll](https://6qfxa-ryaaa-aaaai-qbhsq-cai.icp0.io/#/thread/835836) computed by VP-weighting. Attention: this is a temporary solution for delaying the minting until we have figured out a more elegant model doing what we want.
- Fix: top 100 holders chart
- Fix: paging on landing leading to too short streams