### PR TITLE
feat: Implement profile pictures

### DIFF
--- a/src/backend/env/post.rs
+++ b/src/backend/env/post.rs
@@ -1,5 +1,7 @@
 use std::cmp::{Ordering, PartialOrd};
 
+use self::user::Avatar;
+
 use super::reports::ReportState;
 use super::*;
 use super::{storage::Storage, user::UserId};
@@ -55,6 +57,7 @@ pub struct Meta<'a> {
     author_name: &'a str,
     author_rewards: i64,
     author_filters: UserFilter,
+    author_avatar: Option<Avatar>,
     viewer_blocked: bool,
     realm_color: Option<&'a str>,
 }
@@ -154,6 +157,7 @@ impl Post {
             author_name: user.name.as_str(),
             author_rewards: user.rewards(),
             author_filters: user.filters.noise.clone(),
+            author_avatar: user.avatar.clone(),
             viewer_blocked: state
                 .principal_to_user(caller())
                 .map(|viewer| user.blacklist.contains(&viewer.id))

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -67,6 +67,21 @@ impl UserFilter {
     }
 }
 
+/// Contains the location of the Avatar image blob.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Avatar {
+    // The canister id of the bucket canister.
+    pub bucket_id: String,
+    pub offset: u64,
+    pub len: usize,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct UserData {
+    pub name: String,
+    pub avatar: Option<Avatar>,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct User {
     pub id: UserId,
@@ -111,6 +126,8 @@ pub struct User {
     pub miner: bool,
     #[serde(default)]
     pub controlled_realms: HashSet<RealmId>,
+    #[serde(default)]
+    pub avatar: Option<Avatar>,
 }
 
 impl User {
@@ -185,6 +202,7 @@ impl User {
             miner: true,
             downvotes: Default::default(),
             show_posts_in_realms: true,
+            avatar: None,
         }
     }
 
@@ -484,6 +502,7 @@ impl User {
         governance: bool,
         miner: bool,
         show_posts_in_realms: bool,
+        clear_avatar: bool,
     ) -> Result<(), String> {
         if read(|state| {
             state
@@ -520,6 +539,9 @@ impl User {
                 user.miner = miner;
                 user.filters.noise = filter;
                 user.show_posts_in_realms = show_posts_in_realms;
+                if clear_avatar {
+                    user.avatar = None;
+                }
                 if let Some(name) = new_name {
                     user.previous_names.push(user.name.clone());
                     user.name = name;

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -1,7 +1,10 @@
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
-use crate::env::{token::Token, user::UserFilter};
+use crate::{
+    env::{token::Token, user::UserFilter},
+    user::UserData,
+};
 
 use super::*;
 use candid::Principal;
@@ -66,12 +69,19 @@ fn distribution() {
 
 #[export_name = "canister_query users_data"]
 fn users_data() {
+    fn user_data(user: &User) -> UserData {
+        UserData {
+            name: user.name.clone(),
+            avatar: user.avatar.clone(),
+        }
+    }
+
     read(|state| {
         let ids: Vec<UserId> = parse(&arg_data_raw());
         reply(
             ids.into_iter()
                 .filter_map(|id| state.users.get(&id))
-                .map(|user| (user.id, &user.name))
+                .map(|user| (user.id, user_data(&user)))
                 .collect::<HashMap<_, _>>(),
         );
     });

--- a/src/backend/taggr.did
+++ b/src/backend/taggr.did
@@ -66,4 +66,5 @@ service : () -> {
   set_emergency_release : (vec nat8) -> ();
   stable_mem_read : (nat64) -> (vec record { nat64; vec nat8 }) query;
   unlink_cold_wallet : () -> (Result_1);
+  upload_avatar: (vec nat8) -> (Result_1);
 }

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -89,6 +89,8 @@ export type Backend = {
         amount: number,
         fee: number,
     ) => Promise<string | number>;
+
+    upload_avatar: (blob: Uint8Array) => Promise<JsonValue | null>;
 };
 
 export const ApiGenerator = (
@@ -436,6 +438,18 @@ export const ApiGenerator = (
                 owner: account.owner,
                 subaccount: account.subaccount,
             });
+        },
+
+        upload_avatar: async (blob: Uint8Array): Promise<JsonValue | null> => {
+            const arg = IDL.encode([IDL.Vec(IDL.Nat8)], [blob]);
+            const response = await call_raw(undefined, "upload_avatar", arg);
+            if (!response) {
+                return null;
+            }
+            return IDL.decode(
+                [IDL.Variant({ Ok: IDL.Null, Err: IDL.Text })],
+                response,
+            )[0];
         },
     };
 };

--- a/src/frontend/src/header.tsx
+++ b/src/frontend/src/header.tsx
@@ -5,7 +5,6 @@ import {
     IconToggleButton,
     RealmList,
     ToggleButton,
-    UserLink,
 } from "./common";
 import { LoginMasks, logout } from "./logins";
 import {
@@ -181,7 +180,12 @@ export const Header = ({
                 </div>
             </header>
             {showLogins && <LoginMasks />}
-            {showUserSection && <UserSection user={user} />}
+            {showUserSection && (
+                <UserSection
+                    user={user}
+                    hide={() => toggleUserSection(false)}
+                />
+            )}
             {showLinks && <Links />}
             {showRealms && (
                 <RealmList
@@ -194,21 +198,10 @@ export const Header = ({
     );
 };
 
-const UserSection = ({ user }: { user: UserType }) => {
+const UserSection = ({ user, hide }: { user: UserType; hide: () => void }) => {
     return (
         <div className="bottom_spaced stands_out">
             <div className="column_container centered">
-                {user && (
-                    <span className="xx_large_text bottom_spaced">
-                        <User classNameArg="right_half_spaced" />{" "}
-                        <UserLink
-                            profile={true}
-                            id={user.id}
-                            name={user.name}
-                        />
-                    </span>
-                )}
-
                 <div className="row_container icon_bar top_half_spaced">
                     {user && (
                         <>
@@ -218,6 +211,14 @@ const UserSection = ({ user }: { user: UserType }) => {
                                 href={`/#/journal/${user.name}`}
                             >
                                 <Journal /> JOURNAL
+                            </a>
+                            <a
+                                title="PROFILE"
+                                className="icon_link"
+                                href={`/#/user/${user.id}`}
+                                onClick={hide}
+                            >
+                                <User /> PROFILE
                             </a>
                             <a
                                 title="INVITES"

--- a/src/frontend/src/image.ts
+++ b/src/frontend/src/image.ts
@@ -1,0 +1,103 @@
+import { blobToUrl } from "./common";
+
+const MAX_IMG_SIZE = 16777216;
+
+export const imageTooLarge = (image: HTMLImageElement) =>
+    iOS() && image.height * image.width > MAX_IMG_SIZE;
+
+export const imageHash = async (buffer: ArrayBuffer): Promise<string> => {
+    const result = await crypto.subtle.digest("SHA-256", buffer);
+    const hashArray = Array.from(new Uint8Array(result)).slice(0, 4);
+    return hashArray
+        .map((bytes) => bytes.toString(16).padStart(2, "0"))
+        .join("");
+};
+
+export const loadFile = (file: any): Promise<ArrayBuffer> => {
+    const reader = new FileReader();
+    return new Promise((resolve, reject) => {
+        reader.onerror = () => {
+            reader.abort();
+            reject(alert("Couldn't upload file!"));
+        };
+        reader.onload = () => resolve(reader.result as ArrayBuffer);
+        reader.readAsArrayBuffer(file);
+    });
+};
+
+export const loadImage = (blob: ArrayBuffer): Promise<HTMLImageElement> => {
+    const image = new Image();
+    return new Promise((resolve) => {
+        image.onload = () => resolve(image);
+        image.src = blobToUrl(blob);
+    });
+};
+
+/// Resizes the given image by the given scale.
+export const rescaleImage = async (
+    blob: ArrayBuffer,
+    scale: number,
+): Promise<ArrayBuffer> => {
+    const image = await loadImage(blob);
+    const canvas = drawOnCanvas(
+        image,
+        image.width * scale,
+        image.height * scale,
+    );
+    return await canvasToBlob(canvas);
+};
+
+/// Resizes the given image such that it fits the given dimensions.
+export const resizeImage = async (
+    blob: ArrayBuffer,
+    max_width: number,
+    max_height: number,
+): Promise<ArrayBuffer> => {
+    const image = await loadImage(blob);
+    const canvas = drawOnCanvas(image, max_width, max_height);
+    return await canvasToBlob(canvas);
+};
+
+/// Extracts the image blob from the given canvas element.
+const canvasToBlob = (canvas: HTMLCanvasElement): Promise<ArrayBuffer> =>
+    new Promise((resolve) =>
+        canvas.toBlob(
+            (blob) => blob && blob.arrayBuffer().then(resolve),
+            "image/jpeg",
+            0.5,
+        ),
+    );
+
+/// Draws the given image on a canvas element of the given maximum size by
+/// resizing the image to fit the canvas and returns the canvas element.
+const drawOnCanvas = (
+    image: HTMLImageElement,
+    max_width: number,
+    max_height: number,
+): HTMLCanvasElement => {
+    let width = image.width;
+    let height = image.height;
+    // Take the maximum in order to make the largest dimention fit.
+    let scale = Math.max(width / max_width, height / max_height, 1.0);
+    width = width / scale;
+    height = height / scale;
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+        ctx.clearRect(0, 0, width, height);
+        ctx.drawImage(image, 0, 0, width, height);
+    }
+    return canvas;
+};
+
+const iOS = () =>
+    [
+        "iPad Simulator",
+        "iPhone Simulator",
+        "iPod Simulator",
+        "iPad",
+        "iPhone",
+        "iPod",
+    ].includes(navigator.platform);

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -32,7 +32,7 @@ import { Tokens, TransactionView, TransactionsView } from "./tokens";
 import { Whitepaper } from "./whitepaper";
 import { Recovery } from "./recovery";
 import { MAINNET_MODE, CANISTER_ID } from "./env";
-import { PostId, User, UserData } from "./types";
+import { PostId, User, UserDataMap } from "./types";
 import { setRealmUI, setUI } from "./theme";
 import { Search } from "./search";
 import { Distribution } from "./distribution";
@@ -312,11 +312,15 @@ AuthClient.create({ idleOptions: { disableIdle: true } }).then(
                 let data = await api.query<User>("user", []);
                 if (data) {
                     window.api
-                        .query<UserData>("users_data", data.followees)
-                        .then(
-                            (names) =>
-                                (window.backendCache.followees = names || {}),
-                        );
+                        .query<UserDataMap>("users_data", data.followees)
+                        .then((user_data) => {
+                            const followees = Object.fromEntries(
+                                Object.entries(user_data || {}).map(
+                                    ([k, v]) => [k, v.name],
+                                ),
+                            );
+                            window.backendCache.followees = followees;
+                        });
                     window.user = data;
                     window.user.realms.reverse();
                     if (600000 < microSecsSince(window.user.last_activity)) {

--- a/src/frontend/src/journal.tsx
+++ b/src/frontend/src/journal.tsx
@@ -36,13 +36,15 @@ export const Journal = ({ handle }: { handle: string }) => {
         <>
             {profile && (
                 <div className="text_centered">
-                    <h1>
+                    <h1 className="vcentered centered nowrap">
                         <UserLink
                             id={profile.id}
-                            name={profile.name}
+                            user_data={{ name: profile.name }}
                             profile={true}
+                            classNameArg="centered"
+                            suffix="'s"
                         />
-                        's Journal
+                        &nbsp;journal
                     </h1>
                     {
                         <Content

--- a/src/frontend/src/profile.tsx
+++ b/src/frontend/src/profile.tsx
@@ -17,6 +17,7 @@ import {
     RealmList,
     noiseControlBanner,
     UserList,
+    avatarToUrl,
 } from "./common";
 import { Content } from "./content";
 import { Journal } from "./icons";
@@ -79,7 +80,15 @@ export const Profile = ({ handle }: { handle: string }) => {
     return (
         <>
             <HeadBar
-                title={profile.name}
+                title=<>
+                    {profile.avatar && (
+                        <img
+                            className="avatar_large left_well_spaced right_spaced"
+                            src={avatarToUrl(profile.avatar)}
+                        ></img>
+                    )}
+                    {profile.name}
+                </>
                 button1={
                     <button
                         title={`${profile.name}'s journal`}

--- a/src/frontend/src/realms.tsx
+++ b/src/frontend/src/realms.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { loadFile } from "./form";
+import { loadFile } from "./image";
 import {
     BurgerButton,
     ButtonWithLoading,

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -1151,3 +1151,34 @@ div.thumbnails {
     margin-top: 0.4em;
     padding: 0.1em 0 0.1em 0;
 }
+
+div.avatar_container {
+    display: block;
+    margin-right: 0.3rem;
+    line-height: 24px;
+}
+
+.comment img.avatar,
+img.avatar {
+    max-width: 100%;
+    max-height: 100%;
+    height: 24px;
+    width: 24px;
+    margin: 0px;
+    object-fit: cover;
+    border-radius: 30px;
+    vertical-align: middle;
+}
+
+img.avatar_large {
+    height: 64px;
+    width: 64px;
+    object-fit: cover;
+    border-radius: 60px;
+    vertical-align: middle;
+}
+
+.top_aligned {
+    display: flex;
+    align-items: start;
+}

--- a/src/frontend/src/tokens.tsx
+++ b/src/frontend/src/tokens.tsx
@@ -401,7 +401,9 @@ export const TransactionsView = ({
                                     User{" "}
                                     <UserLink
                                         id={identifiedUser.id}
-                                        name={identifiedUser.name}
+                                        user_data={{
+                                            name: identifiedUser.name,
+                                        }}
                                     />
                                 </h3>
                                 <Content value={identifiedUser.about} />

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -99,6 +99,7 @@ export type Meta = {
     author_name: string;
     author_rewards: number;
     author_filters: UserFilter;
+    author_avatar?: Avatar;
     viewer_blocked: boolean;
     realm_color: string;
 };
@@ -188,6 +189,12 @@ export type UserFilter = {
     downvotes: number;
 };
 
+export type Avatar = {
+    bucket_id: string;
+    offset: number;
+    len: number;
+};
+
 export type User = {
     name: string;
     id: UserId;
@@ -229,6 +236,7 @@ export type User = {
     filters: Filters;
     blacklist: UserId[];
     notifications: { [key: number]: [Notification, boolean] };
+    avatar?: Avatar;
 };
 
 export type Report = {
@@ -241,7 +249,11 @@ export type Report = {
 };
 
 export type Theme = { [name: string]: any };
-export type UserData = { [id: UserId]: string };
+export type UserData = {
+    name: string;
+    avatar?: Avatar;
+};
+export type UserDataMap = { [id: UserId]: UserData };
 
 declare global {
     interface Window {
@@ -263,7 +275,7 @@ declare global {
         lastSavedUpgrade: number;
         uiInitialized: boolean;
         backendCache: {
-            followees: UserData;
+            followees: { [id: UserId]: string };
             recent_tags: string[];
             stats: {
                 fees_burned: number;


### PR DESCRIPTION
This allows a user to upload a profile picture via settings.
The profile picture is rendered in posts and comments as thumbnail.

Changes in the backend:
- add an `avatar` field to `User`.
- add an `avatar` field to `Meta`.
- add an `upload_avatar` update endpoint.
- extend existing queries to return avatar.

Changes in the frontend:
- move image helper functions to `image.ts`.
- add a profile picture field in the settings.
- show the cost of saving the settings on the button label.
- add a new `AvatarElement` helper.
- extend `UserData` to include the avatar URL.
- extend `UserLink` and `UserList` to pass user data.
- replace the user name in the header page with a new PROFILE link.
- display the profile picture in posts, comments, and profile.