### PR TITLE
Release

### DIFF
--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -762,7 +762,7 @@ impl State {
                 to: account(author.principal),
                 fee: Some(1), // special tipping fee
                 amount: amount as u128,
-                memo: None,
+                memo: Some(format!("Tips on post {}", post_id).as_bytes().to_vec()),
                 created_at_time: None,
             },
         )

--- a/src/backend/env/post.rs
+++ b/src/backend/env/post.rs
@@ -53,7 +53,6 @@ pub enum Extension {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Meta<'a> {
     author_name: &'a str,
-    author_rewards: i64,
     author_filters: UserFilter,
     viewer_blocked: bool,
     realm_color: Option<&'a str>,
@@ -152,7 +151,6 @@ impl Post {
             .and_then(|realm_id| state.realms.get(realm_id));
         let meta = Meta {
             author_name: user.name.as_str(),
-            author_rewards: user.rewards(),
             author_filters: user.filters.noise.clone(),
             viewer_blocked: state
                 .principal_to_user(caller())

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -117,6 +117,7 @@ pub struct User {
     pub show_posts_in_realms: bool,
     pub posts: Vec<PostId>,
     // TODO: delete
+    #[serde(skip)]
     pub miner: bool,
     pub controlled_realms: HashSet<RealmId>,
     #[serde(default)]

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -149,11 +149,9 @@ impl User {
     }
 
     pub fn controversial(&self) -> bool {
-        self.rewards < 0
-            || self
-                .post_reports
-                .values()
-                .any(|timestamp| timestamp + CONFIG.user_report_validity_days * DAY >= time())
+        self.post_reports
+            .values()
+            .any(|timestamp| timestamp + CONFIG.user_report_validity_days * DAY >= time())
             || self
                 .report
                 .as_ref()

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -79,15 +79,7 @@ fn post_upgrade() {
 }
 
 #[allow(clippy::all)]
-fn sync_post_upgrade_fixtures() {
-    mutate(|state| {
-        for u in state.users.values_mut() {
-            u.mode = if u.miner { Mode::Mining } else { Mode::Rewards };
-            // clean up of old settings still present for some users
-            u.settings.retain(|key, _| !key.ends_with("_tab"));
-        }
-    })
-}
+fn sync_post_upgrade_fixtures() {}
 
 #[allow(clippy::all)]
 async fn async_post_upgrade_fixtures() {}

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -509,6 +509,16 @@ const PostInfo = ({
                     You're blocked by this user.
                 </div>
             );
+        else if (
+            realmData &&
+            realmData.whitelist.length > 0 &&
+            !realmData.whitelist.includes(user.id)
+        )
+            realmAccessError = (
+                <div className="banner vertically_spaced">
+                    This realm is gated by a whitelist.
+                </div>
+            );
         else if (realmData)
             realmAccessError = noiseControlBanner(
                 "realm",

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -896,7 +896,7 @@ const PostBar = ({
     };
 
     return (
-        <>
+        <div onClick={goInside}>
             <div
                 ref={ref}
                 className="active"
@@ -994,7 +994,7 @@ const PostBar = ({
                     </>
                 )}
             </div>
-        </>
+        </div>
     );
 };
 
@@ -1013,6 +1013,7 @@ export const ReactionPicker = ({
             justifyContent: "flex-start",
             padding: "0.5em",
         }}
+        data-meta="skipClicks"
     >
         {window.backendCache.config.reactions.map(([reactId, rewards]) => (
             <button
@@ -1051,6 +1052,7 @@ export const Reactions = ({
                 return (
                     <button
                         key={reactId}
+                        data-meta="skipClicks"
                         className={
                             "reaction_button button_text " +
                             (reacted ? "selected" : "unselected")

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -205,7 +205,7 @@ export const PostView = ({
             post.reactions,
             (acc, id, users) => acc + costTable[id as any] * users.length,
             0,
-        ) < 0 || post.meta.author_rewards < 0;
+        ) < 0;
     const user = window.user;
     const showReport =
         post.report && !post.report.closed && user && user.stalwart;

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -25,7 +25,6 @@ import {
     currentRealm,
     parseNumber,
     noiseControlBanner,
-    ArrowDown,
 } from "./common";
 import {
     reaction2icon,
@@ -44,7 +43,7 @@ import {
     More,
 } from "./icons";
 import { ProposalView } from "./proposals";
-import { Post, PostId, Realm, UserId } from "./types";
+import { BlogTitle, Post, PostId, Realm, UserId } from "./types";
 import { MAINNET_MODE } from "./env";
 import { UserLink, UserList, populateUserNameCache } from "./user_resolve";
 
@@ -85,11 +84,9 @@ export const PostView = ({
     const [showComments, toggleComments] = React.useState(!!prime);
     const [showInfo, toggleInfo] = React.useState(false);
     const [safeToOpen, setSafeToOpen] = React.useState(false);
-    const [showExpandButton, setShowExpandButton] = React.useState(false);
     const [commentIncoming, setCommentIncoming] = React.useState(false);
 
     const refPost = React.useRef();
-    const refArticle = React.useRef();
 
     const loadData = async (preloadedData?: Post) => {
         const data = preloadedData || (await loadPosts([id])).pop();
@@ -117,18 +114,6 @@ export const PostView = ({
     React.useEffect(() => {
         loadData(data);
     }, [id, version, data]);
-
-    React.useEffect(() => {
-        const article: any = refArticle.current;
-        if (
-            (isFeedItem || repost) &&
-            article &&
-            article.scrollHeight > article.clientHeight
-        ) {
-            article.classList.add("overflowing");
-            setShowExpandButton(true);
-        }
-    }, [post]);
 
     if (!post) {
         if (notFound) return <NotFound />;
@@ -328,23 +313,13 @@ export const PostView = ({
                     </div>
                 )}
                 {!isNSFW && (
-                    <article
-                        ref={refArticle as unknown as any}
-                        onClick={(e) => goInside(e)}
-                    >
-                        <Content
-                            blogTitle={blogTitle}
-                            post={true}
-                            value={body}
-                            collapse={!expanded}
-                            primeMode={isRoot(post) && !repost}
-                            urls={urls}
-                        />
-                    </article>
-                )}
-                {showExpandButton && (
-                    <ArrowDown
-                        onClick={() => (location.href = `#/post/${post.id}`)}
+                    <PostContent
+                        blogTitle={blogTitle}
+                        expanded={expanded}
+                        value={body}
+                        primeMode={isRoot(post) && !repost && !isFeedItem}
+                        urls={urls}
+                        goInside={goInside}
                     />
                 )}
                 {showExtension && "Poll" in post.extension && (
@@ -448,6 +423,71 @@ const Comments = ({
                 </li>
             ))}
         </ul>
+    );
+};
+
+const PostContent = ({
+    goInside,
+    expanded,
+    blogTitle,
+    primeMode,
+    urls,
+    value,
+}: {
+    blogTitle?: BlogTitle;
+    primeMode: boolean;
+    expanded?: boolean;
+    goInside: any;
+    urls: { [id: string]: string };
+    value: string;
+}) => {
+    // All posts in non-prime mode should be collapsed if they are too long. The problem with
+    // deterministic collapsing is that the height of a DOM element is only known when this element
+    // is rendered. The rendering itself is asynchronous and transparent to the React framework.
+    // So there is a fundamental limitation to how much we can do from inside the React itself.
+    //
+    // To work around this limitation, we do the following. First, we render the container of
+    // the post and then, once we have the link to the DOM element, we make 10 attempts lasting at
+    // most 1s in total, where we try to measure the height of the container and the height of its
+    // content. If the content is longer that the container height, we mark the post as overflowing
+    // which displays the post with a gradient below.
+    //
+    // In the worst case (if the content takes longer than 1s to render), this post will be cut but
+    // not display the gradient.
+    //
+    // The reason why it needs to be delayed and implemented asynchronously is that
+    // the post content itself is rendered asynchronously as well: it takes non-zero time to render
+    // long posts, let alone to load and render an image. The markdown library we use does not provide
+    // any reliable callback mechanism notofying about the end of the rendering.
+    const [renderingAttempts, setRenderingAttempts] = React.useState(
+        primeMode ? 0 : 10,
+    );
+    const refArticle = React.useRef();
+
+    React.useEffect(() => {
+        if (renderingAttempts == 0) return;
+        setTimeout(() => {
+            const article: any = refArticle.current;
+            if (article && article.scrollHeight > article.clientHeight) {
+                article.classList.add("overflowing");
+                setRenderingAttempts(0);
+            } else {
+                setRenderingAttempts(renderingAttempts - 1);
+            }
+        }, 100);
+    }, [renderingAttempts]);
+
+    return (
+        <article ref={refArticle as unknown as any} onClick={goInside}>
+            <Content
+                blogTitle={blogTitle}
+                post={true}
+                value={value}
+                collapse={!expanded}
+                primeMode={primeMode}
+                urls={urls}
+            />
+        </article>
     );
 };
 

--- a/src/frontend/src/profile.tsx
+++ b/src/frontend/src/profile.tsx
@@ -452,6 +452,14 @@ export const UserInfo = ({ profile }: { profile: User }) => {
                         </span>
                     </div>
                 )}
+                {Object.entries(profile.downvotes).length > 0 && (
+                    <div className="db_cell">
+                        DOWNVOTERS (7d)
+                        <code style={{ color: "red" }}>
+                            {Object.entries(profile.downvotes).length}
+                        </code>
+                    </div>
+                )}
             </div>
             <hr />
             {(feeds || profile.realms.length > 0) && (

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -765,7 +765,7 @@ a.reply_tag {
 }
 
 .button_text {
-    font-size: small;
+    font-size: x-small;
 }
 
 .small_text {
@@ -1098,10 +1098,6 @@ label svg {
 
     article img {
         width: 100%;
-    }
-
-    .button_text {
-        font-size: x-small;
     }
 
     .mobile_only {

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -222,7 +222,7 @@ article {
 }
 
 .feed_item article {
-    max-height: 100vh;
+    max-height: 90vh;
     position: relative;
 }
 

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -99,7 +99,6 @@ export type Realm = {
 
 export type Meta = {
     author_name: string;
-    author_rewards: number;
     author_filters: UserFilter;
     viewer_blocked: boolean;
     realm_color: string;


### PR DESCRIPTION
- remove user descrimination based on the rewards balance - now a negative rewards balance only matters for minting eligibility and receiving of ICP rewards: in both cases the user needs to "pay off" the rewards debt if they get into the red. But they are not grayed out anymore
- feat: add post id into tipping memos
- feat: do not display the text field for posts on gated realms if the user is not whitelisted
- feat: show the number of unique downvoters in the last 7 days on the profile (this is more helpful for users themselves because they might have no access to realms and don't know why)
- feat: allow opening the post by clicking anywhere on the post bar
- fix: fix wrong cutting on long posts (cutting the content in the middle)
