### PR TITLE
Refactoring of proposal creations

### DIFF
--- a/e2e/test1.spec.ts
+++ b/e2e/test1.spec.ts
@@ -42,7 +42,7 @@ test.describe("Upgrades & token transfer flow", () => {
         // Create a post
         await page.getByRole("button", { name: "POST" }).click();
         await page.locator("textarea").fill("Message from Eve");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
 
         // Create an invite
@@ -199,9 +199,7 @@ test.describe("Upgrades & token transfer flow", () => {
             page.getByRole("heading", { name: "PROPOSALS" }),
         ).toBeVisible();
         await page.getByTestId("proposals-burger-button").click();
-        await page.getByRole("button", { name: "RELEASE" }).click();
         await page.locator("textarea").fill("A regular upgrade");
-        await page.locator("input[type=text]").fill("coffeecoffeecoffee");
 
         // Upload the binary
         const binaryPath = resolve(
@@ -215,11 +213,14 @@ test.describe("Upgrades & token transfer flow", () => {
 
         const [fileChooser] = await Promise.all([
             page.waitForEvent("filechooser"),
-            page.locator('input[type="file"]').click(),
+            page.getByTestId("bin-file-picker").click(),
         ]);
 
         const buildHash = await hashFile(binaryPath);
         await fileChooser.setFiles([binaryPath]);
+        // Wait for async proposal validation
+        await page.waitForTimeout(2000);
+        await page.locator("input[type=text]").fill("coffeecoffeecoffee");
         await page.getByRole("button", { name: "SUBMIT" }).click();
         await expect(page.getByText(/STATUS.*OPEN/)).toBeVisible();
         await expect(page.getByText("TYPE: RELEASE")).toBeVisible();

--- a/e2e/test2.spec.ts
+++ b/e2e/test2.spec.ts
@@ -86,7 +86,7 @@ test.describe("Regular users flow", () => {
             page.getByTestId("file-picker").click(),
         ]);
         await fileChooser.setFiles([imagePath]);
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
 
         // Make sure the post loads
@@ -102,7 +102,7 @@ test.describe("Regular users flow", () => {
         await page
             .locator("textarea")
             .fill(value + "\n\n**Edit:** this is a post-scriptum");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
         await expect(page.getByText("post-scriptum")).toBeVisible();
 
@@ -192,7 +192,7 @@ test.describe("Regular users flow", () => {
         // Now we can create a new post in the new realm
         await page.getByRole("button", { name: "POST" }).click();
         await page.locator("#form_undefined_3").fill("Hello from Alice!");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
 
         // Make sure the post is visible on the front page and is labeled with realm tag
         await page.locator("#logo").click();
@@ -245,7 +245,7 @@ test.describe("Regular users flow", () => {
             .click();
         await page.getByPlaceholder("Reply here...").focus();
         await page.locator("textarea").fill("Bob was here");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
 
         // Wait because the UI waits for 4s before sending the command
         await page.waitForTimeout(4000);

--- a/e2e/test3.spec.ts
+++ b/e2e/test3.spec.ts
@@ -43,7 +43,7 @@ test.describe("Regular users flow, part two", () => {
         await page.locator("textarea").fill("Poll from John");
         await page.getByTestId("poll-button").click();
         await page.getByTestId("poll-editor").fill("YES\nNO\nCOMMENTS");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
 
         // Make sure the post loads
@@ -85,7 +85,7 @@ test.describe("Regular users flow, part two", () => {
         await feedItem.locator("button[title=Repost]").click();
         await page.waitForURL(/#\/new/);
         await page.locator("textarea").fill("Repost of the poll");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
 
         // Make sure the post is visible on the front page too

--- a/e2e/test4.spec.ts
+++ b/e2e/test4.spec.ts
@@ -61,7 +61,7 @@ test.describe("Report and transfer to user", () => {
         await page.locator("#logo").click();
         await page.getByRole("button", { name: "POST" }).click();
         await page.locator("textarea").fill("Good stuff");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
     });
 
@@ -78,7 +78,7 @@ test.describe("Report and transfer to user", () => {
         await page.locator("#logo").click();
         await page.getByRole("button", { name: "POST" }).click();
         await page.locator("textarea").fill("Illigal stuff");
-        await page.getByRole("button", { name: "SEND" }).click();
+        await page.getByRole("button", { name: "SUBMIT" }).click();
         await page.waitForURL(/#\/post\//);
     });
 

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -2828,25 +2828,6 @@ fn covered_by_feeds(
     None
 }
 
-pub fn parse_amount(amount: &str, token_decimals: u8) -> Result<u64, String> {
-    let parse = |s: &str| {
-        s.parse::<u64>()
-            .map_err(|err| format!("couldn't parse as u64: {:?}", err))
-    };
-    match &amount.split('.').collect::<Vec<_>>().as_slice() {
-        [tokens] => Ok(parse(tokens)? * 10_u64.pow(token_decimals as u32)),
-        [tokens, after_comma] => {
-            let mut after_comma = after_comma.to_string();
-            while after_comma.len() < token_decimals as usize {
-                after_comma.push('0');
-            }
-            let after_comma = &after_comma[..token_decimals as usize];
-            Ok(parse(tokens)? * 10_u64.pow(token_decimals as u32) + parse(after_comma)?)
-        }
-        _ => Err(format!("can't parse amount {}", amount)),
-    }
-}
-
 pub fn display_tokens(amount: u64, decimals: u32) -> String {
     let base = 10_u64.pow(decimals);
     if decimals == 8 {

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -2962,18 +2962,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_amount_parsing() {
-        assert_eq!(parse_amount("12.34", 8), Ok(1234000000));
-        assert_eq!(parse_amount("0.0034", 8), Ok(340000));
-        assert_eq!(parse_amount("00.67", 2), Ok(67));
-        assert_eq!(parse_amount("1.25", 2), Ok(125));
-        assert_eq!(parse_amount("123.4567", 2), Ok(12345));
-        assert_eq!(parse_amount("777", 2), Ok(77700));
-        assert_eq!(parse_amount("0777", 2), Ok(77700));
-        assert!(parse_amount("34,56", 2).is_err());
-    }
-
-    #[test]
     fn test_donated_rewards() {
         STATE.with(|cell| {
             cell.replace(Default::default());
@@ -3370,7 +3358,7 @@ pub(crate) mod tests {
             let user = state.principal_to_user_mut(pr(1)).unwrap();
             user.stalwart = true;
             let user_id = user.id;
-            let proposal_id = proposals::propose(
+            let proposal_id = proposals::tests::propose(
                 state,
                 pr(1),
                 "test".into(),

--- a/src/backend/env/proposals.rs
+++ b/src/backend/env/proposals.rs
@@ -245,7 +245,7 @@ impl Payload {
                 if !state.users.contains_key(user_id) {
                     return Err("user not found".to_string());
                 }
-                if !state.realms.contains_key(realm_id) {
+                if !state.realms.contains_key(&realm_id.to_uppercase()) {
                     return Err("realm not found".to_string());
                 }
             }

--- a/src/backend/env/proposals.rs
+++ b/src/backend/env/proposals.rs
@@ -100,7 +100,11 @@ impl Proposal {
                     return Err("wrong hash".into());
                 }
             }
-            Payload::Funding(_, _) => {}
+            Payload::Funding(receiver, _) => {
+                if receiver == &principal {
+                    return Err("reward receivers can not vote".into());
+                }
+            }
             Payload::Rewards(Rewards {
                 votes, receiver, ..
             }) => {

--- a/src/backend/env/proposals.rs
+++ b/src/backend/env/proposals.rs
@@ -2,7 +2,7 @@ use super::config::CONFIG;
 use super::post::{Extension, Post, PostId};
 use super::token::{self, account};
 use super::user::Predicate;
-use super::{invoices, HOUR};
+use super::{invoices, RealmId, HOUR};
 use super::{user::UserId, State};
 use crate::mutate;
 use crate::token::Token;
@@ -22,7 +22,8 @@ pub enum Status {
     Cancelled,
 }
 
-#[derive(Deserialize, Serialize)]
+// TODO: remove Clone
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Release {
     pub commit: String,
     pub hash: String,
@@ -32,22 +33,36 @@ pub struct Release {
 
 type ProposedReward = Token;
 
-#[derive(Deserialize, Serialize)]
+// TODO: remove Clone
+#[derive(Clone, Deserialize, Serialize)]
+pub struct Rewards {
+    pub receiver: Principal,
+    pub votes: Vec<(Token, ProposedReward)>,
+    pub minted: Token,
+}
+
+// TODO: remove Clone
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Reward {
     pub receiver: String,
     pub votes: Vec<(Token, ProposedReward)>,
     pub minted: Token,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+// TODO: remove Clone
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub enum Payload {
     #[default]
     Noop,
     Release(Release),
+    // TODO: delete
     Fund(String, Token),
     ICPTransfer(AccountIdentifier, Tokens),
+    // TODO: delete
     Reward(Reward),
-    AddRealmController(String, UserId),
+    AddRealmController(RealmId, UserId),
+    Funding(Principal, Token),
+    Rewards(Rewards),
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -85,17 +100,8 @@ impl Proposal {
                     return Err("wrong hash".into());
                 }
             }
-            Payload::Fund(receiver, _) => {
-                if Principal::from_text(receiver) == Ok(principal) {
-                    return Err("funding receivers can not vote".into());
-                }
-            }
-            Payload::Reward(Reward {
-                receiver, votes, ..
-            }) => {
-                if Principal::from_text(receiver) == Ok(principal) {
-                    return Err("reward receivers can not vote".into());
-                }
+            Payload::Funding(_, _) => {}
+            Payload::Rewards(Rewards { votes, .. }) => {
                 let minting_ratio = state.minting_ratio();
                 let base = token::base();
                 let max_funding_amount = CONFIG.max_funding_amount / minting_ratio / base;
@@ -165,14 +171,14 @@ impl Proposal {
 
         if approvals * 100 >= voting_power * CONFIG.proposal_approval_threshold as u64 {
             match &mut self.payload {
-                Payload::Fund(receiver, tokens) => mint_tokens(state, receiver, *tokens)?,
-                Payload::Reward(reward) => {
+                Payload::Funding(receiver, tokens) => mint_tokens(state, *receiver, *tokens)?,
+                Payload::Rewards(reward) => {
                     let total: Token = reward.votes.iter().map(|(vp, _)| vp).sum();
                     let tokens_to_mint: Token =
                         reward.votes.iter().fold(0.0, |acc, (vp, reward)| {
                             acc + *vp as f32 / total as f32 * *reward as f32
                         }) as Token;
-                    mint_tokens(state, &reward.receiver, tokens_to_mint)?;
+                    mint_tokens(state, reward.receiver, tokens_to_mint)?;
                     reward.votes.clear();
                     reward.minted = tokens_to_mint;
                 }
@@ -212,8 +218,7 @@ impl Proposal {
     }
 }
 
-fn mint_tokens(state: &mut State, receiver: &str, mut tokens: Token) -> Result<(), String> {
-    let receiver = Principal::from_text(receiver).map_err(|e| e.to_string())?;
+fn mint_tokens(state: &mut State, receiver: Principal, mut tokens: Token) -> Result<(), String> {
     state.minting_mode = true;
     crate::token::mint(state, account(receiver), tokens);
     state.minting_mode = false;
@@ -232,7 +237,7 @@ fn mint_tokens(state: &mut State, receiver: &str, mut tokens: Token) -> Result<(
 }
 
 impl Payload {
-    fn validate(&mut self, state: &State) -> Result<(), String> {
+    pub fn validate(&self, state: &State) -> Result<(), String> {
         let minting_ratio = state.minting_ratio();
         let current_supply: Token = state.balances.values().sum();
         match self {
@@ -251,15 +256,11 @@ impl Payload {
                 if release.binary.is_empty() {
                     return Err("binary is missing".to_string());
                 }
-                let mut hasher = Sha256::new();
-                hasher.update(&release.binary);
-                release.hash = format!("{:x}", hasher.finalize());
             }
-            Payload::Fund(controller, tokens) => {
-                Principal::from_text(controller).map_err(|err| err.to_string())?;
+            Payload::Funding(_, tokens) => {
                 if current_supply >= CONFIG.maximum_supply {
                     return Err(
-                        "no funding is allowed when the curent supply is above maximum".into(),
+                        "no funding is allowed when the current supply is above maximum".into(),
                     );
                 }
                 let max_funding_amount = CONFIG.max_funding_amount / minting_ratio;
@@ -270,10 +271,10 @@ impl Payload {
                     ));
                 }
             }
-            Payload::Reward(_) => {
+            Payload::Rewards(_) => {
                 if current_supply >= CONFIG.maximum_supply {
                     return Err(
-                        "no funding is allowed when the curent supply is above maximum".into(),
+                        "no rewards are allowed when the current supply is above maximum".into(),
                     );
                 }
             }
@@ -283,22 +284,30 @@ impl Payload {
     }
 }
 
-pub fn propose(
+pub fn create_proposal(
     state: &mut State,
     caller: Principal,
-    description: String,
+    post_id: PostId,
     mut payload: Payload,
     time: u64,
 ) -> Result<u32, String> {
+    if Post::get(state, &post_id).is_none() {
+        return Err("post not found".to_string());
+    }
     payload.validate(state)?;
+
+    // For an upgrade release proposal, compute the binary hash
+    if let Payload::Release(release) = &mut payload {
+        let mut hasher = Sha256::new();
+        hasher.update(&release.binary);
+        release.hash = format!("{:x}", hasher.finalize());
+    }
+
     let user = state
         .principal_to_user_mut(caller)
         .ok_or("proposer user not found")?;
     if !user.stalwart {
         return Err("only stalwarts can create proposals".to_string());
-    }
-    if description.is_empty() {
-        return Err("description is empty".to_string());
     }
     if !user.realms.contains(&CONFIG.dao_realm.to_owned()) {
         user.realms.push(CONFIG.dao_realm.to_owned());
@@ -320,17 +329,6 @@ pub fn propose(
 
     let id = state.proposals.len() as u32;
 
-    let post_id = Post::create(
-        state,
-        description,
-        Default::default(),
-        caller,
-        time,
-        None,
-        Some(CONFIG.dao_realm.to_owned()),
-        Some(Extension::Proposal(id)),
-    )?;
-
     state.proposals.push(Proposal {
         post_id,
         proposer,
@@ -348,6 +346,11 @@ pub fn propose(
         format!("@{} submitted a new proposal", &proposer_name,),
         Predicate::Proposal(post_id),
     );
+    Post::mutate(state, &post_id, |post| {
+        post.extension = Some(Extension::Proposal(id));
+        Ok(())
+    })
+    .expect("couldn't mutate post");
     state.logger.info(format!(
         "@{} submitted a new [proposal](#/post/{}).",
         &proposer_name, post_id

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -1,7 +1,7 @@
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
-use crate::env::{token::Token, user::UserFilter};
+use crate::env::{proposals::Payload, token::Token, user::UserFilter};
 
 use super::*;
 use candid::Principal;
@@ -508,6 +508,12 @@ fn thread() {
 fn recent_tags() {
     let (realm, n): (String, u64) = parse(&arg_data_raw());
     read(|state| reply(state.recent_tags(optional(realm), n)));
+}
+
+#[export_name = "canister_query validate_proposal"]
+fn validate_proposal() {
+    let payload: Payload = parse(&arg_data_raw());
+    read(|state| reply(payload.validate(state)));
 }
 
 #[export_name = "canister_query validate_username"]

--- a/src/backend/taggr.did
+++ b/src/backend/taggr.did
@@ -62,7 +62,7 @@ service : () -> {
   icrc1_transfer : (TransferArgs) -> (Result_3);
   link_cold_wallet : (nat64) -> (Result_1);
   prod_release : () -> (bool);
-  propose_release : (text, text, vec nat8) -> (Result_4);
+  propose_release : (nat64, text, vec nat8) -> (Result_4);
   set_emergency_release : (vec nat8) -> ();
   stable_mem_read : (nat64) -> (vec record { nat64; vec nat8 }) query;
   unlink_cold_wallet : () -> (Result_1);

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -1,12 +1,13 @@
-use crate::env::user::{Mode, UserFilter};
+use crate::env::{
+    proposals::{Payload, Release, Reward, Rewards},
+    user::{Mode, UserFilter},
+};
 
 use super::*;
 use env::{
     canisters::get_full_neuron,
     config::CONFIG,
-    parse_amount,
     post::{Extension, Post, PostId},
-    proposals::{Release, Reward},
     user::{Draft, User, UserId},
     State,
 };
@@ -19,7 +20,6 @@ use ic_cdk::{
 };
 use ic_cdk_macros::{init, post_upgrade, pre_upgrade, update};
 use ic_cdk_timers::{set_timer, set_timer_interval};
-use ic_ledger_types::{AccountIdentifier, Tokens};
 use serde_bytes::ByteBuf;
 use std::time::Duration;
 
@@ -81,12 +81,28 @@ fn post_upgrade() {
 #[allow(clippy::all)]
 fn sync_post_upgrade_fixtures() {
     mutate(|state| {
-        for u in state.users.values_mut() {
-            u.mode = if u.miner { Mode::Mining } else { Mode::Rewards };
-            // clean up of old settings still present for some users
-            u.settings.retain(|key, _| !key.ends_with("_tab"));
+        for p in state.proposals.iter_mut() {
+            p.payload = migrate_payload(p.payload.clone());
         }
     })
+}
+
+fn migrate_payload(p: Payload) -> Payload {
+    match p {
+        Payload::Fund(receiver, tokens) => {
+            Payload::Funding(Principal::from_text(receiver).unwrap(), tokens)
+        }
+        Payload::Reward(Reward {
+            receiver,
+            votes,
+            minted,
+        }) => Payload::Rewards(Rewards {
+            receiver: Principal::from_text(receiver).unwrap(),
+            minted,
+            votes,
+        }),
+        val => val,
+    }
 }
 
 #[allow(clippy::all)]
@@ -292,49 +308,21 @@ fn create_invite() {
     mutate(|state| reply(state.create_invite(caller(), credits)));
 }
 
-#[export_name = "canister_update propose_add_realm_controller"]
-fn propose_add_realm_controller() {
-    let (description, user_id, realm_id): (String, UserId, RealmId) = parse(&arg_data_raw());
+#[export_name = "canister_update create_proposal"]
+fn create_proposal() {
+    let (post_id, payload): (PostId, Payload) = parse(&arg_data_raw());
     reply(mutate(|state| {
-        proposals::propose(
-            state,
-            caller(),
-            description,
-            proposals::Payload::AddRealmController(realm_id, user_id),
-            time(),
-        )
+        proposals::create_proposal(state, caller(), post_id, payload, time())
     }))
 }
 
-#[export_name = "canister_update propose_icp_transfer"]
-fn propose_icp_transfer() {
-    let (description, receiver, amount): (String, String, String) = parse(&arg_data_raw());
-    reply({
-        match (
-            AccountIdentifier::from_hex(&receiver),
-            parse_amount(&amount, 8),
-        ) {
-            (Ok(account), Ok(amount)) => mutate(|state| {
-                proposals::propose(
-                    state,
-                    caller(),
-                    description,
-                    proposals::Payload::ICPTransfer(account, Tokens::from_e8s(amount)),
-                    time(),
-                )
-            }),
-            (Err(err), _) | (_, Err(err)) => Err(err),
-        }
-    })
-}
-
 #[update]
-fn propose_release(description: String, commit: String, binary: ByteBuf) -> Result<u32, String> {
+fn propose_release(post_id: PostId, commit: String, binary: ByteBuf) -> Result<u32, String> {
     mutate(|state| {
-        proposals::propose(
+        proposals::create_proposal(
             state,
             caller(),
-            description,
+            post_id,
             proposals::Payload::Release(Release {
                 commit,
                 binary: binary.to_vec(),
@@ -342,38 +330,6 @@ fn propose_release(description: String, commit: String, binary: ByteBuf) -> Resu
             }),
             time(),
         )
-    })
-}
-
-#[export_name = "canister_update propose_reward"]
-fn propose_reward() {
-    let (description, receiver): (String, String) = parse(&arg_data_raw());
-    mutate(|state| {
-        reply(proposals::propose(
-            state,
-            caller(),
-            description,
-            proposals::Payload::Reward(Reward {
-                receiver,
-                votes: Default::default(),
-                minted: 0,
-            }),
-            time(),
-        ))
-    })
-}
-
-#[export_name = "canister_update propose_funding"]
-fn propose_funding() {
-    let (description, receiver, tokens): (String, String, u64) = parse(&arg_data_raw());
-    mutate(|state| {
-        reply(proposals::propose(
-            state,
-            caller(),
-            description,
-            proposals::Payload::Fund(receiver, tokens * token::base()),
-            time(),
-        ))
     })
 }
 

--- a/src/frontend/src/api.ts
+++ b/src/frontend/src/api.ts
@@ -8,6 +8,7 @@ import {
     IcrcTransferError,
     IcrcAccount,
 } from "@dfinity/ledger-icrc";
+import { PostId } from "./types";
 
 export type Backend = {
     query: <T>(
@@ -43,7 +44,7 @@ export type Backend = {
     unlink_cold_wallet: () => Promise<JsonValue | null>;
 
     propose_release: (
-        text: string,
+        postId: PostId,
         commit: string,
         blob: Uint8Array,
     ) => Promise<JsonValue | null>;
@@ -242,13 +243,13 @@ export const ApiGenerator = (
         },
 
         propose_release: async (
-            text: string,
+            postId: PostId,
             commit: string,
             blob: Uint8Array,
         ): Promise<JsonValue | null> => {
             const arg = IDL.encode(
-                [IDL.Text, IDL.Text, IDL.Vec(IDL.Nat8)],
-                [text, commit, blob],
+                [IDL.Nat64, IDL.Text, IDL.Vec(IDL.Nat8)],
+                [postId, commit, blob],
             );
             const response = await call_raw(undefined, "propose_release", arg);
             if (!response) {

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -314,6 +314,7 @@ export const ButtonWithLoading = ({
     classNameArg,
     styleArg,
     testId,
+    disabled,
 }: {
     id?: string;
     label: any;
@@ -322,13 +323,14 @@ export const ButtonWithLoading = ({
     classNameArg?: string;
     styleArg?: any;
     testId?: any;
+    disabled?: boolean;
 }) => {
     let [loading, setLoading] = React.useState(false);
     return (
         <button
             id={id}
             title={title}
-            disabled={loading}
+            disabled={disabled || loading}
             className={`fat ${
                 loading ? classNameArg?.replaceAll("active", "") : classNameArg
             }`}

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -87,6 +87,7 @@ export const FileUploadInput = ({
 }) => (
     <input
         type="file"
+        data-testid="bin-file-picker"
         className={classNameArg}
         onChange={async (ev) => {
             const files = (

--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -170,7 +170,7 @@ export const Form = ({
                 setLines(3);
                 setShowTextField(false);
             }
-            if (isRootPost) {
+            if (isRootPost || editMode) {
                 window.resetUI();
                 location.href = `#/post/${postId}`;
             }
@@ -324,7 +324,8 @@ export const Form = ({
     }
 
     const isRepost = repost != null && !isNaN(repost);
-    const isRootPost = postId == null;
+    const isRootPost = postId == undefined;
+    const editMode = !isRootPost && !comment;
     const showPreview = value || isRepost;
 
     const preview = (
@@ -387,6 +388,7 @@ export const Form = ({
             {!showTextField && (
                 <input
                     type="text"
+                    className="bottom_spaced"
                     placeholder="Reply here..."
                     onFocus={() => setShowTextField(true)}
                 />

--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -549,6 +549,7 @@ export const Form = ({
                                     />
                                 )}
                                 {!comment &&
+                                    !proposalForm &&
                                     user.realms.length > 0 &&
                                     (!realm || user.realms.includes(realm)) && (
                                         <select

--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -19,11 +19,13 @@ import {
     Paperclip,
     Quote,
     Table,
+    Balloon,
 } from "./icons";
 import { PostView } from "./post";
-import { Extension, Poll as PollType, PostId } from "./types";
+import { Extension, Payload, Poll as PollType, PostId } from "./types";
 import { PollView } from "./poll";
 import { USER_CACHE } from "./user_resolve";
+import { ProposalMask, ProposalType } from "./proposals";
 
 const MAX_IMG_SIZE = 16777216;
 const MAX_SUGGESTED_TAGS = 5;
@@ -48,7 +50,7 @@ export const Form = ({
         blobs: [string, Uint8Array][],
         extension: Extension | undefined,
         realm: string | undefined,
-    ) => Promise<boolean>;
+    ) => Promise<PostId | null>;
     writingCallback?: (arg: string) => void;
     repost?: PostId;
     urls?: { [id: string]: string };
@@ -60,6 +62,10 @@ export const Form = ({
     const [submitting, setSubmitting] = React.useState(false);
     const [lines, setLines] = React.useState(3);
     const [totalCosts, setTotalCosts] = React.useState(0);
+    const [showProposalMask, setShowProposalMask] = React.useState(false);
+    const [proposalType, setProposalType] = React.useState<ProposalType>(
+        ProposalType.Release,
+    );
     const [dragAndDropping, setDragAndDropping] = React.useState(false);
     const [tmpBlobs, setTmpBlobs] = React.useState<{
         [name: string]: Uint8Array;
@@ -69,6 +75,8 @@ export const Form = ({
     }>({});
     const [busy, setBusy] = React.useState(false);
     const [poll, setPoll] = React.useState<PollType>();
+    const [proposal, setProposal] = React.useState<Payload>();
+    const [proposalIsValid, setProposalIsValid] = React.useState(true);
     const [showTextField, setShowTextField] = React.useState(
         !!localStorage.getItem(draftKey) || expanded,
     );
@@ -77,6 +85,7 @@ export const Form = ({
     const [suggestedRealms, setSuggestedRealms] = React.useState<string[]>([]);
     const [choresTimer, setChoresTimer] = React.useState<any>(null);
     const [cursor, setCursor] = React.useState(0);
+    const [status, setStatus] = React.useState("");
     const textarea = React.useRef<HTMLTextAreaElement>();
     const form = React.useRef();
     const tags = window.backendCache.recent_tags;
@@ -129,18 +138,41 @@ export const Form = ({
             } else if (repost != undefined) {
                 extension = { Repost: repost };
             }
-            const result = await submitCallback(
+            const postId = await submitCallback(
                 value,
                 blobArrays,
                 extension,
                 realm,
             );
-            if (result) {
+            if (postId != null) {
+                if (proposal) {
+                    let result =
+                        "Release" in proposal
+                            ? await window.api.propose_release(
+                                  postId,
+                                  proposal.Release.commit,
+                                  proposal.Release.binary,
+                              )
+                            : await window.api.call<any>(
+                                  "create_proposal",
+                                  postId,
+                                  proposal,
+                              );
+                    if (result && "Err" in result) {
+                        alert(
+                            `Post could be created, but the proposal creation failed: ${result.Err}`,
+                        );
+                    }
+                }
                 setValue("");
                 clearTimeout(choresTimer);
                 localStorage.removeItem(draftKey);
                 setLines(3);
                 setShowTextField(false);
+            }
+            if (isRootPost) {
+                window.resetUI();
+                location.href = `#/post/${postId}`;
             }
         }
         setSubmitting(false);
@@ -292,6 +324,7 @@ export const Form = ({
     }
 
     const isRepost = repost != null && !isNaN(repost);
+    const isRootPost = postId == null;
     const showPreview = value || isRepost;
 
     const preview = (
@@ -465,11 +498,29 @@ export const Form = ({
                                 <div className="max_width_col"></div>
                                 <Credits />
                                 <code
-                                    className="left_half_spaced"
+                                    className="left_half_spaced right_spaced"
                                     data-testid="credit-cost"
                                 >{`${totalCosts}`}</code>
+                                {user.stalwart &&
+                                    !poll &&
+                                    isRootPost &&
+                                    !isRepost && (
+                                        <IconToggleButton
+                                            title="Create a proposal"
+                                            classNameArg="reaction_button action left_spaced clickable"
+                                            pressed={showProposalMask}
+                                            data-testid="proposal-button"
+                                            onClick={() =>
+                                                setShowProposalMask(
+                                                    !showProposalMask,
+                                                )
+                                            }
+                                            icon={<Balloon />}
+                                        />
+                                    )}
                                 <label
                                     id="file_picker_label"
+                                    title="Attach a picture"
                                     htmlFor="file-picker"
                                     className="action left_spaced clickable"
                                     data-testid="file-picker"
@@ -484,34 +535,39 @@ export const Form = ({
                                     accept=".png, .jpg, .jpeg, .gif"
                                     onChange={dropHandler}
                                 />
-                                {postId == null && !isRepost && (
-                                    <IconToggleButton
-                                        testId="poll-button"
-                                        classNameArg="left_half_spaced"
-                                        icon={<Bars />}
-                                        pressed={!!poll}
-                                        onClick={() => {
-                                            setPoll(
-                                                poll &&
-                                                    confirm("Delete the poll?")
-                                                    ? undefined
-                                                    : {
-                                                          options: [
-                                                              "Option 1",
-                                                              "Option 2",
-                                                              "...",
-                                                          ],
-                                                          votes: {},
-                                                          voters: [],
-                                                          deadline: 24,
-                                                          weighted_by_karma: {},
-                                                          weighted_by_tokens:
-                                                              {},
-                                                      },
-                                            );
-                                        }}
-                                    />
-                                )}
+                                {isRootPost &&
+                                    !isRepost &&
+                                    !showProposalMask && (
+                                        <IconToggleButton
+                                            testId="poll-button"
+                                            classNameArg="left_half_spaced"
+                                            icon={<Bars />}
+                                            pressed={!!poll}
+                                            onClick={() => {
+                                                setPoll(
+                                                    poll &&
+                                                        confirm(
+                                                            "Delete the poll?",
+                                                        )
+                                                        ? undefined
+                                                        : {
+                                                              options: [
+                                                                  "Option 1",
+                                                                  "Option 2",
+                                                                  "...",
+                                                              ],
+                                                              votes: {},
+                                                              voters: [],
+                                                              deadline: 24,
+                                                              weighted_by_karma:
+                                                                  {},
+                                                              weighted_by_tokens:
+                                                                  {},
+                                                          },
+                                                );
+                                            }}
+                                        />
+                                    )}
                                 {!comment &&
                                     user.realms.length > 0 &&
                                     (!realm || user.realms.includes(realm)) && (
@@ -532,15 +588,72 @@ export const Form = ({
                                             ))}
                                         </select>
                                     )}
-                                {!tooExpensive && (
-                                    <ButtonWithLoading
-                                        classNameArg="active left_spaced"
-                                        label="SEND"
-                                        onClick={handleSubmit}
-                                    />
-                                )}
                             </div>
                         </div>
+                    )}
+                    {showProposalMask && (
+                        <>
+                            <div className="top_spaced row_container vcentered">
+                                <span className="right_spaced">
+                                    PROPOSAL TYPE
+                                </span>
+                                <select
+                                    className="max_width_col"
+                                    value={proposalType}
+                                    onChange={(e) =>
+                                        setProposalType(
+                                            e.target.value as unknown as any,
+                                        )
+                                    }
+                                >
+                                    {Object.values(ProposalType).map((id) => (
+                                        <option key={id} value={id}>
+                                            {id}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                            <ProposalMask
+                                proposalType={proposalType}
+                                saveProposal={async (proposal) => {
+                                    // Release proposals contain a binary and need a special handling
+                                    if ("Release" in proposal) {
+                                        if (
+                                            !proposal.Release.commit ||
+                                            proposal.Release.binary.length == 0
+                                        ) {
+                                            setStatus(
+                                                "commit or the binary is missing",
+                                            );
+                                            setProposalIsValid(false);
+                                            return;
+                                        }
+                                        setProposalIsValid(true);
+                                        setStatus("");
+                                        return;
+                                    }
+
+                                    let result = await window.api.query<any>(
+                                        "validate_proposal",
+                                        proposal,
+                                    );
+                                    if (
+                                        result == null ||
+                                        (result && "Err" in result)
+                                    ) {
+                                        setStatus(
+                                            result
+                                                ? result.Err
+                                                : "invalid inputs",
+                                        );
+                                        setProposalIsValid(false);
+                                        return;
+                                    } else setProposalIsValid(true);
+                                    setStatus("");
+                                    setProposal(proposal);
+                                }}
+                            />
+                        </>
                     )}
                     {poll && (
                         <div className="column_container bottom_spaced">
@@ -580,6 +693,21 @@ export const Form = ({
                 </form>
             )}
             {!previewAtLeft && showPreview && preview}
+            {status && (
+                <div className="accent bottom_spaced">
+                    Proposal validation failed: {status}
+                </div>
+            )}
+            {!tooExpensive && (
+                <ButtonWithLoading
+                    disabled={!proposalIsValid}
+                    classNameArg={
+                        "active" + (proposalIsValid ? "" : " inactive")
+                    }
+                    label="SUBMIT"
+                    onClick={handleSubmit}
+                />
+            )}
         </div>
     );
 };

--- a/src/frontend/src/new.tsx
+++ b/src/frontend/src/new.tsx
@@ -34,7 +34,7 @@ export const PostSubmissionForm = ({
         blobs: [string, Uint8Array][],
         extension: Extension | undefined,
         realm: string | undefined,
-    ): Promise<boolean> => {
+    ): Promise<PostId | null> => {
         let postId;
         text = text.trim();
         const optionalRealm = realm ? [realm] : [];
@@ -49,7 +49,7 @@ export const PostSubmissionForm = ({
             );
             if ("Err" in response) {
                 alert(`Error: ${response.Err}`);
-                return false;
+                return null;
             }
             postId = post.id;
         } else {
@@ -72,7 +72,7 @@ export const PostSubmissionForm = ({
                 let error: any = results.find((result: any) => "Err" in result);
                 if (error) {
                     alert(`Error: ${error.Err}`);
-                    return false;
+                    return null;
                 }
                 result = await window.api.commit_post();
             } else {
@@ -86,7 +86,7 @@ export const PostSubmissionForm = ({
             }
             if ("Err" in result) {
                 alert(`Error: ${result.Err}`);
-                return false;
+                return null;
             }
             // this is the rare case when a blob triggers the creation of a new bucket
             if (window.backendCache.stats.buckets.length == 0) {
@@ -94,9 +94,7 @@ export const PostSubmissionForm = ({
             }
             postId = result.Ok;
         }
-        window.resetUI();
-        location.href = `#/post/${postId}`;
-        return true;
+        return Number(postId);
     };
 
     if (id != undefined && !isNaN(id) && !post) return null;

--- a/src/frontend/src/proposals.tsx
+++ b/src/frontend/src/proposals.tsx
@@ -17,6 +17,8 @@ import { HourGlass } from "./icons";
 import { PostFeed } from "./post_feed";
 import { Payload, PostId, Proposal, User } from "./types";
 import { UserLink, UserList } from "./user_resolve";
+import { Form } from "./form";
+import { newPostCallback } from "./new";
 
 const REPO_RELEASE = "https://github.com/TaggrNetwork/taggr/releases/latest";
 const REPO_COMMIT = "https://github.com/TaggrNetwork/taggr/commit";
@@ -38,6 +40,15 @@ export const Proposals = () => (
             shareLink="proposals"
             menu={true}
             burgerTestId="proposals-burger-button"
+            content={
+                <>
+                    <h2>New Proposal Form</h2>
+                    <Form
+                        proposalForm={true}
+                        submitCallback={newPostCallback}
+                    />
+                </>
+            }
         />
         <PostFeed
             useList={true}
@@ -567,3 +578,19 @@ function hexToBytes(hex: string) {
         bytes.push(parseInt(hex.substr(i, 2), 16));
     return bytes;
 }
+
+export const validateProposal = async (proposal: Payload) => {
+    // Release proposals contain a binary and need a special handling
+    if ("Release" in proposal) {
+        if (!proposal.Release.commit || proposal.Release.binary.length == 0) {
+            return "commit or the binary missing";
+        }
+        return null;
+    }
+
+    let result = await window.api.query<any>("validate_proposal", proposal);
+    if (result == null || (result && "Err" in result))
+        return result ? result.Err : "invalid inputs";
+
+    return null;
+};

--- a/src/frontend/src/proposals.tsx
+++ b/src/frontend/src/proposals.tsx
@@ -10,323 +10,235 @@ import {
     NotFound,
     tokens,
     hex,
+    parseNumber,
 } from "./common";
 import * as React from "react";
-import { Content } from "./content";
 import { HourGlass } from "./icons";
 import { PostFeed } from "./post_feed";
-import { PostId, Proposal, User } from "./types";
+import { Payload, PostId, Proposal, User } from "./types";
 import { UserLink, UserList } from "./user_resolve";
 
 const REPO_RELEASE = "https://github.com/TaggrNetwork/taggr/releases/latest";
 const REPO_COMMIT = "https://github.com/TaggrNetwork/taggr/commit";
 
-enum ProposalType {
+let timer: any = null;
+
+export enum ProposalType {
     IcpTranfer = "ICP TRANSFER",
     AddRealmController = "ADD REALM CONTROLLER",
-    Fund = "FUND",
-    Reward = "REWARD",
+    Funding = "FUNDING",
+    Rewards = "REWARDS",
     Release = "RELEASE",
 }
 
-export const Proposals = () => {
-    const [proposalType, setProposalType] = React.useState<ProposalType | null>(
-        null,
-    );
+export const Proposals = () => (
+    <>
+        <HeadBar
+            title="PROPOSALS"
+            shareLink="proposals"
+            menu={true}
+            burgerTestId="proposals-burger-button"
+        />
+        <PostFeed
+            useList={true}
+            feedLoader={async (page) =>
+                await window.api.query("proposals", page)
+            }
+        />
+    </>
+);
+
+export const ProposalMask = ({
+    proposalType,
+    saveProposal,
+}: {
+    proposalType: ProposalType;
+    saveProposal: (payload: Payload) => void;
+}) => {
     const [receiver, setReceiver] = React.useState("");
     const [fundingAmount, setFundingAmount] = React.useState(0);
     const [icpAmount, setICPAmount] = React.useState(0);
     const [userName, setUserName] = React.useState("");
     const [realmId, setRealmId] = React.useState("");
-    const [binary, setBinary] = React.useState(null);
+    const [binary, setBinary] = React.useState(new Uint8Array());
     const [commit, setCommit] = React.useState("");
-    const [proposal, setProposal] = React.useState(null);
-    const [description, setDescription] = React.useState("");
+
+    const validateAndSaveProposal = async () => {
+        switch (proposalType) {
+            case ProposalType.AddRealmController:
+                const user = await window.api.query<User>("user", [userName]);
+                if (!user) {
+                    alert(`No user ${userName} found!`);
+                    return;
+                }
+                saveProposal({
+                    ["AddRealmController"]: [realmId, user.id],
+                });
+                break;
+            case ProposalType.IcpTranfer:
+                saveProposal({
+                    ["ICPTransfer"]: [
+                        hexToBytes(receiver),
+                        {
+                            e8s: parseNumber(icpAmount.toString(), 8) || 0,
+                        },
+                    ],
+                });
+                break;
+            case ProposalType.Rewards:
+                saveProposal({
+                    ["Rewards"]: {
+                        receiver,
+                        votes: [],
+                        minted: 0,
+                    },
+                });
+                break;
+            case ProposalType.Funding:
+                saveProposal({
+                    ["Funding"]: [
+                        receiver,
+                        parseNumber(
+                            fundingAmount.toString(),
+                            window.backendCache.config.token_decimals,
+                        ) || 0,
+                    ],
+                });
+                break;
+            default:
+                saveProposal({
+                    ["Release"]: { commit, hash: "", binary },
+                });
+        }
+    };
+
+    React.useEffect(() => {
+        if (
+            receiver ||
+            fundingAmount ||
+            icpAmount ||
+            userName ||
+            realmId ||
+            binary.length > 0 ||
+            commit
+        ) {
+            clearTimeout(timer);
+            timer = setTimeout(validateAndSaveProposal, 1000);
+        }
+    }, [receiver, fundingAmount, icpAmount, userName, realmId, binary, commit]);
 
     return (
-        <>
-            <HeadBar
-                title="PROPOSALS"
-                shareLink="proposals"
-                menu={true}
-                burgerTestId="proposals-burger-button"
-                content={
-                    window.user?.stalwart ? (
-                        <div className="two_columns_grid">
-                            {Object.values(ProposalType).map((id) => (
-                                <button
-                                    key={id}
-                                    className="max_width_col"
-                                    onClick={() => setProposalType(id)}
-                                >
-                                    {id}
-                                </button>
-                            ))}
-                        </div>
-                    ) : undefined
-                }
-            />
-            <div className="vertically_spaced">
-                {proposalType && (
-                    <div className="column_container spaced">
-                        <h1>NEW PROPOSAL: {proposalType?.toString()}</h1>
-                        <div className="bottom_half_spaced">DESCRIPTION</div>
-                        <textarea
-                            className="bottom_spaced"
-                            rows={10}
-                            value={description}
-                            onChange={(event) =>
-                                setDescription(event.target.value)
-                            }
-                        ></textarea>
-                        {description && (
-                            <Content
-                                value={description}
-                                preview={true}
-                                classNameArg="bottom_spaced framed"
-                            />
-                        )}
-                    </div>
-                )}
-                {proposalType == ProposalType.AddRealmController && (
-                    <div className="spaced column_container">
-                        <div className="vcentered bottom_half_spaced">
-                            NEW CONTROLLER
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                value={userName}
-                                onChange={async (ev) => {
-                                    setUserName(ev.target.value);
-                                }}
-                            />
-                        </div>
-                        <div className="vcentered bottom_half_spaced">
-                            REALM
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                value={realmId}
-                                onChange={async (ev) => {
-                                    setRealmId(ev.target.value);
-                                }}
-                            />
-                        </div>
-                        <ButtonWithLoading
-                            classNameArg="top_spaced active"
-                            onClick={async () => {
-                                if (!description || !userName || !realmId) {
-                                    alert("Error: incomplete data.");
-                                    return;
-                                }
-                                const user = await window.api.query<User>(
-                                    "user",
-                                    [name],
-                                );
-                                if (!user) {
-                                    alert(`No user ${userName} found!`);
-                                    return;
-                                }
-                                let response = await window.api.call<any>(
-                                    "propose_add_realm_controller",
-                                    description,
-                                    user.id,
-                                    realmId.toUpperCase(),
-                                );
-                                if ("Err" in response) {
-                                    alert(`Error: ${response.Err}`);
-                                    return;
-                                }
-                                setProposalType(null);
-                                setProposal(response.Ok);
+        <div className="vertically_spaced">
+            {proposalType == ProposalType.AddRealmController && (
+                <div className="spaced column_container">
+                    <div className="vcentered bottom_half_spaced">
+                        NEW CONTROLLER
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            value={userName}
+                            onChange={async (ev) => {
+                                setUserName(ev.target.value);
                             }}
-                            label="SUBMIT"
                         />
                     </div>
-                )}
-                {proposalType == ProposalType.IcpTranfer && (
-                    <div className="spaced column_container">
-                        <div className="vcentered bottom_half_spaced">
-                            RECEIVER
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                onChange={async (ev) => {
-                                    setReceiver(ev.target.value.toString());
-                                }}
-                            />
-                        </div>
-                        <div className="vcentered bottom_half_spaced">
-                            ICP AMOUNT
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                onChange={async (ev) => {
-                                    setICPAmount(Number(ev.target.value));
-                                }}
-                            />
-                        </div>
-                        <ButtonWithLoading
-                            classNameArg="top_spaced active"
-                            onClick={async () => {
-                                if (!description || !receiver || !icpAmount) {
-                                    alert("Error: incomplete data.");
-                                    return;
-                                }
-                                let response = await window.api.call<any>(
-                                    "propose_icp_transfer",
-                                    description,
-                                    receiver,
-                                    icpAmount.toString(),
-                                );
-                                if ("Err" in response) {
-                                    alert(`Error: ${response.Err}`);
-                                    return;
-                                }
-                                setProposalType(null);
-                                setProposal(response.Ok);
+                    <div className="vcentered bottom_half_spaced">
+                        REALM
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            value={realmId}
+                            onChange={async (ev) => {
+                                setRealmId(ev.target.value);
                             }}
-                            label="SUBMIT"
                         />
                     </div>
-                )}
-                {proposalType == ProposalType.Reward && (
-                    <div className="spaced column_container">
-                        <div className="vcentered bottom_half_spaced">
-                            RECEIVER
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                onChange={async (ev) => {
-                                    setReceiver(ev.target.value.toString());
-                                }}
-                            />
-                        </div>
-                        <ButtonWithLoading
-                            classNameArg="top_spaced active"
-                            onClick={async () => {
-                                if (!description || !receiver) {
-                                    alert("Error: incomplete data.");
-                                    return;
-                                }
-                                let response = await window.api.call<any>(
-                                    "propose_reward",
-                                    description,
-                                    receiver,
-                                );
-                                if ("Err" in response) {
-                                    alert(`Error: ${response.Err}`);
-                                    return;
-                                }
-                                setProposalType(null);
-                                setProposal(response.Ok);
+                </div>
+            )}
+            {proposalType == ProposalType.IcpTranfer && (
+                <div className="spaced column_container">
+                    <div className="vcentered bottom_half_spaced">
+                        ICP ADDRESS
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            onChange={async (ev) => {
+                                setReceiver(ev.target.value.toString());
                             }}
-                            label="SUBMIT"
                         />
                     </div>
-                )}
-                {proposalType == ProposalType.Fund && (
-                    <div className="spaced column_container">
-                        <div className="vcentered bottom_half_spaced">
-                            RECEIVER
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                onChange={async (ev) => {
-                                    setReceiver(ev.target.value);
-                                }}
-                            />
-                        </div>
-                        <div className="vcentered bottom_half_spaced">
-                            TOKEN AMOUNT
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                onChange={async (ev) => {
-                                    setFundingAmount(Number(ev.target.value));
-                                }}
-                            />
-                        </div>
-                        <ButtonWithLoading
-                            classNameArg="top_spaced active"
-                            onClick={async () => {
-                                if (
-                                    !description ||
-                                    !receiver ||
-                                    !fundingAmount
-                                ) {
-                                    alert("Error: incomplete data.");
-                                    return;
-                                }
-                                let response = await window.api.call<any>(
-                                    "propose_funding",
-                                    description,
-                                    receiver,
-                                    fundingAmount,
-                                );
-                                if ("Err" in response) {
-                                    alert(`Error: ${response.Err}`);
-                                    return;
-                                }
-                                setProposalType(null);
-                                setProposal(response.Ok);
+                    <div className="vcentered bottom_half_spaced">
+                        ICP AMOUNT
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            onChange={async (ev) => {
+                                setICPAmount(Number(ev.target.value));
                             }}
-                            label="SUBMIT"
                         />
                     </div>
-                )}
-                {proposalType == ProposalType.Release && (
-                    <div className="spaced column_container">
-                        <div className="vcentered bottom_half_spaced">
-                            COMMIT
-                            <input
-                                type="text"
-                                className="left_spaced max_width_col"
-                                onChange={async (ev) => {
-                                    setCommit(ev.target.value);
-                                }}
-                            />
-                        </div>
-                        <div className="vcentered bottom_half_spaced">
-                            BINARY{" "}
-                            <FileUploadInput
-                                classNameArg="left_spaced max_width_col"
-                                callback={setBinary as unknown as any}
-                            />
-                        </div>
-                        <ButtonWithLoading
-                            classNameArg="top_spaced active"
-                            onClick={async () => {
-                                if (!description || !binary) {
-                                    alert("Error: incomplete data.");
-                                    return;
-                                }
-                                const response: any =
-                                    await window.api.propose_release(
-                                        description,
-                                        commit,
-                                        binary,
-                                    );
-                                if ("Err" in response) {
-                                    alert(`Error: ${response.Err}`);
-                                    return;
-                                }
-                                setProposalType(null);
-                                setProposal(response.Ok);
+                </div>
+            )}
+            {proposalType == ProposalType.Rewards && (
+                <div className="spaced column_container">
+                    <div className="vcentered bottom_half_spaced">
+                        PRINCIPAL
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            onChange={async (ev) => {
+                                setReceiver(ev.target.value.toString());
                             }}
-                            label="SUBMIT"
                         />
                     </div>
-                )}
-            </div>
-            <PostFeed
-                heartbeat={proposal}
-                useList={true}
-                feedLoader={async (page) =>
-                    await window.api.query("proposals", page)
-                }
-            />
-        </>
+                </div>
+            )}
+            {proposalType == ProposalType.Funding && (
+                <div className="spaced column_container">
+                    <div className="vcentered bottom_half_spaced">
+                        PRINCIPAL
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            onChange={async (ev) => {
+                                setReceiver(ev.target.value);
+                            }}
+                        />
+                    </div>
+                    <div className="vcentered bottom_half_spaced">
+                        TOKEN AMOUNT
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            onChange={async (ev) => {
+                                setFundingAmount(Number(ev.target.value));
+                            }}
+                        />
+                    </div>
+                </div>
+            )}
+            {proposalType == ProposalType.Release && (
+                <div className="spaced column_container">
+                    <div className="vcentered bottom_half_spaced">
+                        COMMIT
+                        <input
+                            type="text"
+                            className="left_spaced max_width_col"
+                            onChange={async (ev) => {
+                                setCommit(ev.target.value);
+                            }}
+                        />
+                    </div>
+                    <div className="vcentered bottom_half_spaced">
+                        BINARY{" "}
+                        <FileUploadInput
+                            classNameArg="left_spaced max_width_col"
+                            callback={setBinary as unknown as any}
+                        />
+                    </div>
+                </div>
+            )}
+        </div>
     );
 };
 
@@ -528,35 +440,35 @@ export const ProposalView = ({
                     </div>
                 </>
             )}
-            {"Reward" in proposal.payload && (
+            {"Rewards" in proposal.payload && (
                 <>
                     <div className="bottom_half_spaced">
                         RECEIVER:{" "}
                         <code className="breakable">
-                            {proposal.payload.Reward.receiver}
+                            {proposal.payload.Rewards.receiver.toString()}
                         </code>
                     </div>
                     {proposal.status == "Executed" && (
                         <div className="bottom_spaced">
                             TOKENS MINTED:{" "}
                             <code>
-                                {tokenBalance(proposal.payload.Reward.minted)}
+                                {tokenBalance(proposal.payload.Rewards.minted)}
                             </code>
                         </div>
                     )}
                 </>
             )}
-            {"Fund" in proposal.payload && (
+            {"Funding" in proposal.payload && (
                 <>
                     <div className="bottom_half_spaced">
                         RECEIVER:{" "}
                         <code className="breakable">
-                            {proposal.payload.Fund[0]}
+                            {proposal.payload.Funding[0].toString()}
                         </code>
                     </div>
                     <div className="bottom_spaced">
                         AMOUNT:{" "}
-                        <code>{tokenBalance(proposal.payload.Fund[1])}</code>
+                        <code>{tokenBalance(proposal.payload.Funding[1])}</code>
                     </div>
                 </>
             )}
@@ -648,3 +560,10 @@ export const ProposalView = ({
         </div>
     );
 };
+
+function hexToBytes(hex: string) {
+    let bytes = [];
+    for (let i = 0; i < hex.length - 1; i += 2)
+        bytes.push(parseInt(hex.substr(i, 2), 16));
+    return bytes;
+}

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -7,7 +7,7 @@ export type UserId = number;
 export type RealmId = string;
 
 export type ICP = {
-    e8s: BigInt;
+    e8s: BigInt | number;
 };
 
 export type Poll = {
@@ -38,7 +38,7 @@ export type Extension =
           ["Proposal"]: number;
       };
 
-export type Reward = {
+export type Rewards = {
     receiver: string;
     votes: [number, number][];
     minted: number;
@@ -47,6 +47,7 @@ export type Reward = {
 export type Release = {
     commit: string;
     hash: string;
+    binary: Uint8Array;
 };
 
 export type Payload =
@@ -55,7 +56,7 @@ export type Payload =
           ["Release"]: Release;
       }
     | {
-          ["Fund"]: [string, number];
+          ["Funding"]: [string, number];
       }
     | {
           ["ICPTransfer"]: [number[], ICP];
@@ -64,7 +65,7 @@ export type Payload =
           ["AddRealmController"]: [RealmId, UserId];
       }
     | {
-          ["Reward"]: Reward;
+          ["Rewards"]: Rewards;
       };
 
 export type Proposal = {


### PR DESCRIPTION
This change untangles post and proposal creations.

The current implementation that evolved over time (read it is duct-taped), has the limitation that when a stalwart creates a proposal, it can only submit a text which is then used by Taggr to create a post and then attach a corresponding proposal. Unfortunately, this does not allow to attach pictures to proposals (e.g. screenshots) and stands in the way of the next feature I am working on (community roadmap).

In the refactoring we separate the proposal and post creation into different calls, refactor certain proposal types and improve the UI.