### PR TITLE
fix: prevent usage of uninitialized allocator

### DIFF
--- a/src/backend/env/proposals.rs
+++ b/src/backend/env/proposals.rs
@@ -447,6 +447,7 @@ pub mod tests {
     #[should_panic(expected = "couldn't take post 2: not found")]
     fn test_wrong_post_id_in_proposal() {
         mutate(|state| {
+            state.memory.unpack_for_testing();
             create_user(state, pr(1));
             state.principal_to_user_mut(pr(1)).unwrap().stalwart = true;
             create_proposal(state, pr(1), 2, Payload::Noop, 0).unwrap();

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -80,39 +80,42 @@ fn post_upgrade() {
 
 #[allow(clippy::all)]
 fn sync_post_upgrade_fixtures() {
-    mutate(|state| {
-        // Restore corrupted posts 2 & 3
-        use serde_json::json;
-        let post_2 = json!({"id":2,"body":"#hello everyone! I'm [X](#/user/0) the anonymous creator of #Taggr. I wanted to build Taggr for at least 15 years but there was no point to build it on #Web2 to compete with established social platforms. After I've learned about #SNS and #InternetComputer I realized that this is exactly the right moment and the right platform: a public #blockchain on a \"sovereign physical layer\". My main goal is to make #Taggr truly decentralized and make it operate fully autonomously. Then, as a community (if there will be one) we can figure out a sustainable development path for #Taggr.","user":0,"timestamp":1640952386200311995_u64,"children":[151],"parent":null,"watchers":[],"tags":["InternetComputer","SNS","Taggr","Web2","blockchain","hello"],"reactions":{"10":[18446744073709551614_u64,18446744073709551615_u64],"100":[18446744073709551615_u64]},"patches":[],"files":{},"tree_size":1,"tree_update":0,"report":null,"tips":[],"extension":null,"realm":null,"hashes":[],"reposts":[],"heat":0});
-        let post_3 = json!({"id":3,"body":"","user":0,"timestamp":1640954615975657983_i64,"children":[],"parent":null,"watchers":[],"tags":["HappyNewYear","story"],"reactions":{"10":[18446744073709551614_u64,18446744073709551615_u64]},"patches":[],"files":{},"tree_size":0,"tree_update":0,"report":null,"tips":[],"extension":null,"realm":null,"hashes":["c6687c165aaae7c71b08486bbb1e39fd41db0a2605783ebb10dc20d58094f03d"],"reposts":[],"heat":0});
-        state
-            .memory
-            .posts
-            .reinsert(2, serde_json::from_value(post_2).unwrap());
-        state
-            .memory
-            .posts
-            .reinsert(3, serde_json::from_value(post_3).unwrap());
-    });
+    #[cfg(not(any(feature = "dev", feature = "staging")))]
+    {
+        mutate(|state| {
+            // Restore corrupted posts 2 & 3
+            use serde_json::json;
+            let post_2 = json!({"id":2,"body":"#hello everyone! I'm [X](#/user/0) the anonymous creator of #Taggr. I wanted to build Taggr for at least 15 years but there was no point to build it on #Web2 to compete with established social platforms. After I've learned about #SNS and #InternetComputer I realized that this is exactly the right moment and the right platform: a public #blockchain on a \"sovereign physical layer\". My main goal is to make #Taggr truly decentralized and make it operate fully autonomously. Then, as a community (if there will be one) we can figure out a sustainable development path for #Taggr.","user":0,"timestamp":1640952386200311995_u64,"children":[151],"parent":null,"watchers":[],"tags":["InternetComputer","SNS","Taggr","Web2","blockchain","hello"],"reactions":{"10":[18446744073709551614_u64,18446744073709551615_u64],"100":[18446744073709551615_u64]},"patches":[],"files":{},"tree_size":1,"tree_update":0,"report":null,"tips":[],"extension":null,"realm":null,"hashes":[],"reposts":[],"heat":0});
+            let post_3 = json!({"id":3,"body":"","user":0,"timestamp":1640954615975657983_i64,"children":[],"parent":null,"watchers":[],"tags":["HappyNewYear","story"],"reactions":{"10":[18446744073709551614_u64,18446744073709551615_u64]},"patches":[],"files":{},"tree_size":0,"tree_update":0,"report":null,"tips":[],"extension":null,"realm":null,"hashes":["c6687c165aaae7c71b08486bbb1e39fd41db0a2605783ebb10dc20d58094f03d"],"reposts":[],"heat":0});
+            state
+                .memory
+                .posts
+                .reinsert(2, serde_json::from_value(post_2).unwrap());
+            state
+                .memory
+                .posts
+                .reinsert(3, serde_json::from_value(post_3).unwrap());
+        });
 
-    // Restore features
-    mutate(|state| state.memory.features.reset());
-    let mut features = Vec::new();
-    read(|state| {
-        for post_id in 1136641..state.next_post_id {
-            if let Some(post) = Post::get(&state, &post_id) {
-                if !matches!(post.extension, Some(Extension::Feature)) {
-                    continue;
+        // Restore features
+        mutate(|state| state.memory.features.reset());
+        let mut features = Vec::new();
+        read(|state| {
+            for post_id in 1136641..state.next_post_id {
+                if let Some(post) = Post::get(&state, &post_id) {
+                    if !matches!(post.extension, Some(Extension::Feature)) {
+                        continue;
+                    }
+                    let author = state.user(post.user.to_string().as_str()).unwrap();
+                    features.push((author.principal, post_id));
                 }
-                let author = state.user(post.user.to_string().as_str()).unwrap();
-                features.push((author.principal, post_id));
             }
-        }
-    });
+        });
 
-    features
-        .into_iter()
-        .for_each(|(author, post_id)| features::create_feature(author, post_id).unwrap());
+        features
+            .into_iter()
+            .for_each(|(author, post_id)| features::create_feature(author, post_id).unwrap());
+    }
 }
 
 #[allow(clippy::all)]

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -79,7 +79,41 @@ fn post_upgrade() {
 }
 
 #[allow(clippy::all)]
-fn sync_post_upgrade_fixtures() {}
+fn sync_post_upgrade_fixtures() {
+    mutate(|state| {
+        // Restore corrupted posts 2 & 3
+        use serde_json::json;
+        let post_2 = json!({"id":2,"body":"#hello everyone! I'm [X](#/user/0) the anonymous creator of #Taggr. I wanted to build Taggr for at least 15 years but there was no point to build it on #Web2 to compete with established social platforms. After I've learned about #SNS and #InternetComputer I realized that this is exactly the right moment and the right platform: a public #blockchain on a \"sovereign physical layer\". My main goal is to make #Taggr truly decentralized and make it operate fully autonomously. Then, as a community (if there will be one) we can figure out a sustainable development path for #Taggr.","user":0,"timestamp":1640952386200311995_u64,"children":[151],"parent":null,"watchers":[],"tags":["InternetComputer","SNS","Taggr","Web2","blockchain","hello"],"reactions":{"10":[18446744073709551614_u64,18446744073709551615_u64],"100":[18446744073709551615_u64]},"patches":[],"files":{},"tree_size":1,"tree_update":0,"report":null,"tips":[],"extension":null,"realm":null,"hashes":[],"reposts":[],"heat":0});
+        let post_3 = json!({"id":3,"body":"","user":0,"timestamp":1640954615975657983_i64,"children":[],"parent":null,"watchers":[],"tags":["HappyNewYear","story"],"reactions":{"10":[18446744073709551614_u64,18446744073709551615_u64]},"patches":[],"files":{},"tree_size":0,"tree_update":0,"report":null,"tips":[],"extension":null,"realm":null,"hashes":["c6687c165aaae7c71b08486bbb1e39fd41db0a2605783ebb10dc20d58094f03d"],"reposts":[],"heat":0});
+        state
+            .memory
+            .posts
+            .reinsert(2, serde_json::from_value(post_2).unwrap());
+        state
+            .memory
+            .posts
+            .reinsert(3, serde_json::from_value(post_3).unwrap());
+    });
+
+    // Restore features
+    mutate(|state| state.memory.features.reset());
+    let mut features = Vec::new();
+    read(|state| {
+        for post_id in 1136641..state.next_post_id {
+            if let Some(post) = Post::get(&state, &post_id) {
+                if !matches!(post.extension, Some(Extension::Feature)) {
+                    continue;
+                }
+                let author = state.user(post.user.to_string().as_str()).unwrap();
+                features.push((author.principal, post_id));
+            }
+        }
+    });
+
+    features
+        .into_iter()
+        .for_each(|(author, post_id)| features::create_feature(author, post_id).unwrap());
+}
 
 #[allow(clippy::all)]
 async fn async_post_upgrade_fixtures() {}


### PR DESCRIPTION
This MR introduces an initialization logic to the allocator, so that we never run into the corruption issue again.

Additionally we restore all corrupted data, except for the supporter list of features. but users can simply vote on features again.