### PR TITLE
Personal feed improvement

### DIFF
--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1965,7 +1965,7 @@ impl State {
     ) -> Box<dyn Iterator<Item = &'a Post> + 'a> {
         Box::new(
             IteratorMerger::new(
-                tags.into_iter()
+                tags.iter()
                     .map(|tag| {
                         let iterator: Box<dyn Iterator<Item = &PostId>> =
                             match self.tag_indexes.get(tag) {

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1969,7 +1969,7 @@ impl State {
                 tags.iter()
                     .map(|tag| {
                         let iterator: Box<dyn Iterator<Item = &PostId>> =
-                            match self.tag_indexes.get(tag) {
+                            match self.tag_indexes.get(&tag.to_lowercase()) {
                                 Some(index) => Box::new(index.posts.iter()),
                                 None => Box::new(std::iter::empty()),
                             };

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1965,7 +1965,7 @@ impl State {
     ) -> Box<dyn Iterator<Item = &'a Post> + 'a> {
         Box::new(
             IteratorMerger::new(
-                MergeStrategy::AND,
+                MergeStrategy::And,
                 tags.iter()
                     .map(|tag| {
                         let iterator: Box<dyn Iterator<Item = &PostId>> =

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1,7 +1,7 @@
 use self::canisters::{icrc_transfer, upgrade_main_canister, NNSVote};
 use self::invoices::{Invoice, USER_ICP_SUBACCOUNT};
 use self::post::{archive_cold_posts, Extension, Poll, Post, PostId};
-use self::post_iterators::IteratorMerger;
+use self::post_iterators::{IteratorMerger, MergeStrategy};
 use self::proposals::{Payload, Status};
 use self::reports::Report;
 use self::token::{account, TransferArgs};
@@ -1965,6 +1965,7 @@ impl State {
     ) -> Box<dyn Iterator<Item = &'a Post> + 'a> {
         Box::new(
             IteratorMerger::new(
+                MergeStrategy::AND,
                 tags.iter()
                     .map(|tag| {
                         let iterator: Box<dyn Iterator<Item = &PostId>> =

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -124,6 +124,14 @@ pub struct Realm {
 }
 
 #[derive(Default, Serialize, Deserialize)]
+pub struct TagIndex {
+    pub spellings: HashSet<String>,
+    pub subscribers: usize,
+    // Last 1000 posts
+    pub posts: VecDeque<PostId>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
 pub struct Summary {
     pub title: String,
     description: String,
@@ -190,13 +198,19 @@ pub struct State {
 
     last_revenues: VecDeque<u64>,
 
+    // TODO: delete
+    #[serde(skip)]
     pub tag_subscribers: HashMap<String, usize>,
 
     pub distribution_reports: Vec<Summary>,
 
     migrations: BTreeSet<UserId>,
 
+    // TODO: delete
     pub posts_with_tags: Vec<PostId>,
+
+    #[serde(default)]
+    pub tag_indexes: HashMap<String, TagIndex>,
 
     // Indicates whether the end of the stable memory contains a valid heap snapshot.
     #[serde(skip)]

--- a/src/backend/env/post.rs
+++ b/src/backend/env/post.rs
@@ -1073,7 +1073,10 @@ mod tests {
     fn test_hashtag_extraction() {
         let tags = |body| {
             let c = CONFIG;
-            let mut t: Vec<_> = tags(c.max_tag_length, body).into_iter().collect();
+            let mut t: Vec<_> = tags(c.max_tag_length, body)
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect();
             t.sort_unstable();
             t.join(" ")
         };

--- a/src/backend/env/post_iterators.rs
+++ b/src/backend/env/post_iterators.rs
@@ -53,9 +53,9 @@ impl<'a, T: Ord> PartialOrd for DelayedIterator<'a, T> {
 
 pub enum MergeStrategy {
     // Returns all values that appear in at least one iterator exactly once.
-    OR,
+    Or,
     // Returns only values appearing in all iterators at least once.
-    AND,
+    And,
 }
 
 /// Merges all given iterators by ordering of their consumption according to the ordering of their
@@ -131,10 +131,8 @@ impl<'a, T: Clone + Ord> IteratorMerger<'a, T> {
             }
             // If the next value is not larger, then we either have duplicates, or non sorted iterators, we
             // have to skip these values.
-            else {
-                if let Some(more) = next.advance() {
-                    self.values.insert(more);
-                }
+            else if let Some(more) = next.advance() {
+                self.values.insert(more);
             }
         }
         value
@@ -147,8 +145,8 @@ impl<'a, T: Clone + Ord> Iterator for IteratorMerger<'a, T> {
     // Returns the largest value from all iterators
     fn next(&mut self) -> Option<Self::Item> {
         match self.strategy {
-            MergeStrategy::OR => self.next_or(),
-            MergeStrategy::AND => self.next_and(),
+            MergeStrategy::Or => self.next_or(),
+            MergeStrategy::And => self.next_and(),
         }
     }
 }
@@ -159,12 +157,12 @@ mod tests {
 
     #[test]
     fn test_merged_or_iterators_1() {
-        let v1 = vec![9, 7, 4];
-        let v2 = vec![11, 10, 5];
-        let v3 = vec![8, 7, 6, 0];
-        let v4 = vec![11, 3, 3, 3, 2, 1];
+        let v1 = [9, 7, 4];
+        let v2 = [11, 10, 5];
+        let v3 = [8, 7, 6, 0];
+        let v4 = [11, 3, 3, 3, 2, 1];
         let iterator = IteratorMerger::new(
-            MergeStrategy::OR,
+            MergeStrategy::Or,
             vec![
                 Box::new(v1.iter()),
                 Box::new(v2.iter()),
@@ -181,12 +179,12 @@ mod tests {
 
     #[test]
     fn test_merged_or_iterators_2() {
-        let v1 = vec![9, 7, 4];
-        let v2 = vec![11, 10, 5];
-        let v3 = vec![];
-        let v4 = vec![11, 3, 3, 3, 2, 1];
+        let v1 = [9, 7, 4];
+        let v2 = [11, 10, 5];
+        let v3 = [];
+        let v4 = [11, 3, 3, 3, 2, 1];
         let iterator = IteratorMerger::new(
-            MergeStrategy::OR,
+            MergeStrategy::Or,
             vec![
                 Box::new(v1.iter()),
                 Box::new(v2.iter()),
@@ -197,18 +195,18 @@ mod tests {
 
         assert_eq!(
             iterator.collect::<Vec<_>>(),
-            vec![&11, &10, &9, &7, &5, &4, &3, &2, &1]
+            [&11, &10, &9, &7, &5, &4, &3, &2, &1]
         );
     }
 
     #[test]
     fn test_merged_and_iterators_1() {
-        let v1 = vec![9, 7, 4];
-        let v2 = vec![11, 10, 9, 5];
-        let v3 = vec![9, 8, 7, 6, 0];
-        let v4 = vec![12, 11, 9, 3, 3, 3, 2, 1];
+        let v1 = [9, 7, 4];
+        let v2 = [11, 10, 9, 5];
+        let v3 = [9, 8, 7, 6, 0];
+        let v4 = [12, 11, 9, 3, 3, 3, 2, 1];
         let iterator = IteratorMerger::new(
-            MergeStrategy::AND,
+            MergeStrategy::And,
             vec![
                 Box::new(v1.iter()),
                 Box::new(v2.iter()),
@@ -222,12 +220,12 @@ mod tests {
 
     #[test]
     fn test_merged_and_iterators_2() {
-        let v1 = vec![9, 7, 4, 3];
-        let v2 = vec![11, 10, 9, 5, 3];
-        let v3 = vec![9, 8, 7, 6, 3, 0];
-        let v4 = vec![12, 11, 9, 3, 3, 3, 2, 1];
+        let v1 = [9, 7, 4, 3];
+        let v2 = [11, 10, 9, 5, 3];
+        let v3 = [9, 8, 7, 6, 3, 0];
+        let v4 = [12, 11, 9, 3, 3, 3, 2, 1];
         let iterator = IteratorMerger::new(
-            MergeStrategy::AND,
+            MergeStrategy::And,
             vec![
                 Box::new(v1.iter()),
                 Box::new(v2.iter()),
@@ -241,12 +239,12 @@ mod tests {
 
     #[test]
     fn test_merged_and_iterators_3() {
-        let v1 = vec![4, 3, 2, 1];
-        let v2 = vec![4, 3, 2, 1];
-        let v3 = vec![4, 3, 2, 1];
-        let v4 = vec![4, 3, 2, 1];
+        let v1 = [4, 3, 2, 1];
+        let v2 = [4, 3, 2, 1];
+        let v3 = [4, 3, 2, 1];
+        let v4 = [4, 3, 2, 1];
         let iterator = IteratorMerger::new(
-            MergeStrategy::AND,
+            MergeStrategy::And,
             vec![
                 Box::new(v1.iter()),
                 Box::new(v2.iter()),

--- a/src/backend/env/post_iterators.rs
+++ b/src/backend/env/post_iterators.rs
@@ -1,0 +1,82 @@
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+
+/// Wraps a post iterator and implements `Ord` around the peeked element.
+struct DelayedIterator<'a, T> {
+    head: Option<&'a T>,
+    iterator: Box<dyn Iterator<Item = &'a T> + 'a>,
+}
+
+impl<'a, T> DelayedIterator<'a, T> {
+    fn new(mut iterator: Box<dyn Iterator<Item = &'a T> + 'a>) -> Self {
+        Self {
+            head: iterator.next(),
+            iterator,
+        }
+    }
+
+    fn peek(&self) -> Option<&'a T> {
+        self.head
+    }
+
+    fn advance(mut self) -> Option<Self> {
+        self.head = self.iterator.next();
+        self.head?;
+        Some(self)
+    }
+}
+
+impl<'a, T: Eq> PartialEq for DelayedIterator<'a, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.peek() == other.peek()
+    }
+}
+
+impl<'a, T: Eq> Eq for DelayedIterator<'a, T> {}
+
+impl<'a, T: Ord> Ord for DelayedIterator<'a, T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.peek().cmp(&other.peek())
+    }
+}
+
+impl<'a, T: Ord> PartialOrd for DelayedIterator<'a, T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.peek().cmp(&other.peek()))
+    }
+}
+
+/// Merges all given iterators by ordering of their consumption according to the ordering of their
+/// elements. It is currently used to merge many post iterators and to return the newest posts no
+/// matter from which iterator they are served.
+pub struct IteratorMerger<'a, T> {
+    values: BTreeSet<DelayedIterator<'a, T>>,
+}
+
+impl<'a, T: Ord + Eq> IteratorMerger<'a, T> {
+    pub fn new(iterators: Vec<Box<dyn Iterator<Item = &'a T> + 'a>>) -> Self {
+        IteratorMerger {
+            values: iterators
+                .into_iter()
+                .map(|iterator| DelayedIterator::new(iterator))
+                .collect(),
+        }
+    }
+}
+
+impl<'a, T: Clone + Ord> Iterator for IteratorMerger<'a, T> {
+    type Item = &'a T;
+
+    // Returns the largest value from all iterators
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.values.is_empty() {
+            return None;
+        }
+        let next = self.values.pop_last()?;
+        let value = next.peek();
+        if let Some(more) = next.advance() {
+            self.values.insert(more);
+        }
+        value
+    }
+}

--- a/src/backend/env/search.rs
+++ b/src/backend/env/search.rs
@@ -32,32 +32,16 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
 
     match terms.as_slice() {
         [hashtag] if hashtag.starts_with('#') => {
-            let tag = &hashtag[1..].to_lowercase();
+            let query = &hashtag[1..].to_lowercase();
             state
-                .posts_by_tags_and_users(None, 0, &[tag.clone()], Default::default(), true)
-                .filter_map(
-                    |Post {
-                         id,
-                         user,
-                         tags,
-                         body,
-                         ..
-                     }| {
-                        if tags.contains(tag) {
-                            let search_body = body.to_lowercase();
-                            if let Some(i) = search_body.find(hashtag) {
-                                return Some(SearchResult {
-                                    id: *id,
-                                    user_id: *user,
-                                    relevant: snippet(body, i),
-                                    result: "post".to_string(),
-                                    ..Default::default()
-                                });
-                            }
-                        }
-                        None
-                    },
-                )
+                .tag_indexes
+                .keys()
+                .filter(|tag| tag.starts_with(query))
+                .map(|tag| SearchResult {
+                    relevant: tag.clone(),
+                    result: "tag".to_string(),
+                    ..Default::default()
+                })
                 .take(MAX_RESULTS)
                 .collect()
         }

--- a/src/backend/env/search.rs
+++ b/src/backend/env/search.rs
@@ -34,7 +34,7 @@ pub fn search(state: &State, mut query: String) -> Vec<SearchResult> {
         [hashtag] if hashtag.starts_with('#') => {
             let tag = &hashtag[1..].to_lowercase();
             state
-                .posts_with_tags(None, 0, true)
+                .posts_by_tags_and_users(None, 0, &[tag.clone()], Default::default(), true)
                 .filter_map(
                     |Post {
                          id,

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -306,7 +306,7 @@ impl User {
     }
 
     pub fn toggle_following_feed(&mut self, tags: &[String]) -> bool {
-        let tags = tags.into_iter().map(|tag| tag.to_lowercase()).collect();
+        let tags = tags.iter().map(|tag| tag.to_lowercase()).collect();
         if let Some(i) = covered_by_feeds(&self.feeds, &tags, true) {
             self.feeds.remove(i);
             return false;
@@ -335,7 +335,7 @@ impl User {
             iterators.push(state.posts_by_tags_and_users(
                 None,
                 offset,
-                feed.into_iter().cloned().collect::<Vec<_>>().as_slice(),
+                feed.iter().cloned().collect::<Vec<_>>().as_slice(),
                 Default::default(),
                 false,
             ))

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -342,7 +342,7 @@ impl User {
         }
 
         Box::new(
-            IteratorMerger::new(iterators.into_iter().collect())
+            IteratorMerger::new(MergeStrategy::OR, iterators.into_iter().collect())
                 .filter(move |post| {
                     self.followees.contains(&post.user)
                         || !post.matches_filters(&self.filters)

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -87,7 +87,7 @@ pub struct User {
     pub cold_wallet: Option<Principal>,
     cycles: Credits,
     rewards: i64,
-    pub feeds: Vec<BTreeSet<String>>,
+    pub feeds: Vec<Vec<String>>,
     pub followees: BTreeSet<UserId>,
     pub followers: BTreeSet<UserId>,
     pub timestamp: u64,
@@ -332,13 +332,7 @@ impl User {
             .collect();
 
         for feed in self.feeds.iter() {
-            iterators.push(state.posts_by_tags_and_users(
-                None,
-                offset,
-                feed.iter().cloned().collect::<Vec<_>>().as_slice(),
-                Default::default(),
-                false,
-            ))
+            iterators.push(state.posts_by_tags_and_users(None, offset, &feed, false))
         }
 
         Box::new(

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -342,7 +342,7 @@ impl User {
         }
 
         Box::new(
-            IteratorMerger::new(MergeStrategy::OR, iterators.into_iter().collect())
+            IteratorMerger::new(MergeStrategy::Or, iterators.into_iter().collect())
                 .filter(move |post| {
                     self.followees.contains(&post.user)
                         || !post.matches_filters(&self.filters)

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -1,5 +1,5 @@
+use std::cmp::Reverse;
 use std::collections::BTreeMap;
-use std::{cmp::Reverse, collections::HashSet};
 
 use crate::env::{proposals::Payload, token::Token, user::UserFilter};
 
@@ -478,12 +478,12 @@ fn last_posts() {
 
 #[export_name = "canister_query posts_by_tags"]
 fn posts_by_tags() {
-    let (realm, tags, users, page, offset): (String, Vec<String>, HashSet<UserId>, usize, PostId) =
+    let (realm, tags_and_users, page, offset): (String, Vec<String>, usize, PostId) =
         parse(&arg_data_raw());
     read(|state| {
         reply(
             state
-                .posts_by_tags_and_users(optional(realm), offset, &tags, users, false)
+                .posts_by_tags_and_users(optional(realm), offset, &tags_and_users, false)
                 .skip(page * CONFIG.feed_page_size)
                 .take(CONFIG.feed_page_size)
                 .map(|post| post.with_meta(state))

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -1,5 +1,5 @@
-use std::cmp::Reverse;
 use std::collections::BTreeMap;
+use std::{cmp::Reverse, collections::HashSet};
 
 use crate::env::{proposals::Payload, token::Token, user::UserFilter};
 
@@ -478,12 +478,14 @@ fn last_posts() {
 
 #[export_name = "canister_query posts_by_tags"]
 fn posts_by_tags() {
-    let (realm, tags, users, page, offset): (String, Vec<String>, Vec<UserId>, usize, PostId) =
+    let (realm, tags, users, page, offset): (String, Vec<String>, HashSet<UserId>, usize, PostId) =
         parse(&arg_data_raw());
     read(|state| {
         reply(
             state
-                .posts_by_tags(optional(realm), tags, users, page, offset)
+                .posts_by_tags_and_users(optional(realm), offset, &tags, users, false)
+                .skip(page * CONFIG.feed_page_size)
+                .take(CONFIG.feed_page_size)
                 .map(|post| post.with_meta(state))
                 .collect::<Vec<_>>(),
         )

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -95,7 +95,11 @@ fn sync_post_upgrade_fixtures() {
             .posts_with_tags
             .iter()
             .filter_map(|id| Post::get(state, id))
-            .flat_map(|post| post.tags.iter().map(move |tag| (post.id, tag.clone())))
+            .flat_map(|post| {
+                post.tags
+                    .iter()
+                    .map(move |tag| (post.id, tag.to_lowercase()))
+            })
             .collect::<Vec<_>>()
             .into_iter()
         {

--- a/src/frontend/src/feed.tsx
+++ b/src/frontend/src/feed.tsx
@@ -3,7 +3,6 @@ import { currentRealm, HeadBar, setTitle } from "./common";
 import { ToggleButton } from "./common";
 import { PostFeed } from "./post_feed";
 import { PostId } from "./types";
-import { userNameToIds } from "./user_resolve";
 
 export const Feed = ({ params }: { params: string[] }) => {
     const [filter, setFilter] = React.useState(params);
@@ -13,17 +12,10 @@ export const Feed = ({ params }: { params: string[] }) => {
             <FeedBar params={params} callback={setFilter} />
             <PostFeed
                 feedLoader={async (page: number, offset: PostId) => {
-                    const tags: string[] = [],
-                        users: string[] = [];
-                    filter.forEach((token) => {
-                        if (token.startsWith("@")) users.push(token.slice(1));
-                        else tags.push(token);
-                    });
                     return await window.api.query(
                         "posts_by_tags",
                         currentRealm(),
-                        tags,
-                        await userNameToIds(users),
+                        filter,
                         page,
                         offset,
                     );

--- a/src/frontend/src/user_resolve.tsx
+++ b/src/frontend/src/user_resolve.tsx
@@ -24,16 +24,28 @@ export const populateUserNameCache = async (
     );
 };
 
-export const userNameToIds = async (names: string[]) =>
-    (
+export const userNameToIds = async (names: string[]) => {
+    if (names.length == 0) return [];
+    names = names.map((name) => name.trim().replace("@", ""));
+    const cachedNames = Object.entries(USER_CACHE).reduce(
+        (acc, [id, name]) => {
+            acc[name] = Number(id);
+            return acc;
+        },
+        {} as { [name: string]: UserId },
+    );
+    return (
         await Promise.all(
-            names
-                .map((name) => name.trim().replace("@", ""))
-                .map((name) => window.api.query<User>("user", [name])),
+            names.map((name) =>
+                name in cachedNames
+                    ? { id: cachedNames[name] }
+                    : window.api.query<User>("user", [name]),
+            ),
         )
     )
         .map((user) => user?.id)
         .filter((user) => user != undefined);
+};
 
 export const UserLink = ({
     id,


### PR DESCRIPTION
- introduces hash tag indexes (each index keeps only 1000 last posts, which is about 33 scrolling pages).
- introduces an iterator merger (this allows avoid scanning all posts when filtering for the personal feed).
- fixes the hashtag search
- improves the recent_tags query