### PR TITLE
Release

### DIFF
--- a/src/backend/dev_helpers.rs
+++ b/src/backend/dev_helpers.rs
@@ -49,10 +49,13 @@ async fn check() {
 
 #[update]
 async fn clear_buckets() {
-    use canisters::management_canister_call;
     for (canister_id, _) in mutate(|state| std::mem::take(&mut state.storage.buckets)) {
-        let _: Result<(), _> = management_canister_call(canister_id, "stop_canister").await;
-        let _: Result<(), _> = management_canister_call(canister_id, "delete_canister").await;
+        use ic_cdk::api::management_canister::{
+            main::{delete_canister, stop_canister},
+            provisional::CanisterIdRecord,
+        };
+        let _: Result<(), _> = stop_canister(CanisterIdRecord { canister_id }).await;
+        let _: Result<(), _> = delete_canister(CanisterIdRecord { canister_id }).await;
     }
 }
 

--- a/src/backend/dev_helpers.rs
+++ b/src/backend/dev_helpers.rs
@@ -49,11 +49,11 @@ async fn check() {
 
 #[update]
 async fn clear_buckets() {
+    use ic_cdk::api::management_canister::{
+        main::{delete_canister, stop_canister},
+        provisional::CanisterIdRecord,
+    };
     for (canister_id, _) in mutate(|state| std::mem::take(&mut state.storage.buckets)) {
-        use ic_cdk::api::management_canister::{
-            main::{delete_canister, stop_canister},
-            provisional::CanisterIdRecord,
-        };
         let _: Result<(), _> = stop_canister(CanisterIdRecord { canister_id }).await;
         let _: Result<(), _> = delete_canister(CanisterIdRecord { canister_id }).await;
     }

--- a/src/backend/env/canisters.rs
+++ b/src/backend/env/canisters.rs
@@ -82,6 +82,24 @@ pub async fn new() -> Result<Principal, String> {
     Ok(response.canister_id)
 }
 
+/// Returns cycles in the canister and cycles burned per day.
+pub async fn cycles(canister_id: Principal) -> Result<(u64, u64), String> {
+    let CanisterStatusResponse {
+        cycles,
+        idle_cycles_burned_per_day,
+        ..
+    } = status(canister_id).await?;
+    Ok((
+        cycles.0.to_u64_digits().last().copied().unwrap_or_default(),
+        idle_cycles_burned_per_day
+            .0
+            .to_u64_digits()
+            .last()
+            .copied()
+            .unwrap_or(1),
+    ))
+}
+
 pub async fn status(canister_id: Principal) -> Result<CanisterStatusResponse, String> {
     open_call("status");
     let response = canister_status(CanisterIdRecord { canister_id }).await;
@@ -155,14 +173,17 @@ pub async fn topup_with_cycles(canister_id: Principal, cycles: u128) -> Result<(
     Ok(())
 }
 
-pub async fn top_up(canister_id: Principal, min_cycle_balance: u64) -> Result<bool, String> {
-    let (response,): (u64,) = call_canister(canister_id, "balance", ((),))
+pub async fn top_up(canister_id: Principal) -> Result<bool, String> {
+    let (cycles_total, cycles_per_day): (u64, u64) = call_canister(canister_id, "cycles", ((),))
         .await
         .map_err(|err| format!("couldn't call child canister: {:?}", err))?;
-    if response < min_cycle_balance {
-        topup_with_cycles(canister_id, min_cycle_balance as u128)
-            .await
-            .map_err(|err| format!("failed to top up canister {}: {:?}", canister_id, err))?;
+    if cycles_total / cycles_per_day < CONFIG.canister_survival_period_days {
+        topup_with_cycles(
+            canister_id,
+            CONFIG.canister_survival_period_days as u128 * cycles_per_day as u128,
+        )
+        .await
+        .map_err(|err| format!("failed to top up canister {}: {:?}", canister_id, err))?;
         return Ok(true);
     }
     Ok(false)

--- a/src/backend/env/canisters.rs
+++ b/src/backend/env/canisters.rs
@@ -9,21 +9,24 @@ use candid::{
     utils::{ArgumentDecoder, ArgumentEncoder},
     CandidType, Principal,
 };
-use ic_cdk::api::call::{CallResult, RejectionCode};
-use ic_cdk::id;
-use ic_cdk::{
-    api::{
-        call::call_with_payment,
-        call::{call, call_raw},
+use ic_cdk::api::{
+    call::CallResult,
+    management_canister::{
+        main::{
+            canister_status, create_canister, deposit_cycles, install_code, CanisterInstallMode,
+            CanisterStatusResponse, CreateCanisterArgument, InstallCodeArgument,
+        },
+        provisional::CanisterIdRecord,
     },
-    notify,
 };
+use ic_cdk::id;
+use ic_cdk::{api::call::call_raw, notify};
 use ic_ledger_types::MAINNET_GOVERNANCE_CANISTER_ID;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-const CYCLES_FOR_NEW_CANISTER: u64 = 1_000_000_000_000;
+const CYCLES_FOR_NEW_CANISTER: u128 = 1_000_000_000_000;
 
 thread_local! {
     static CALLS: RefCell<HashMap<String, i32>> = Default::default();
@@ -64,87 +67,29 @@ pub fn calls_open() -> usize {
     CALLS.with(|cell| cell.borrow().values().filter(|v| **v > 0).count())
 }
 
-#[derive(CandidType, Deserialize)]
-struct CanisterId {
-    canister_id: Principal,
-}
-
-#[derive(CandidType)]
-struct CanisterSettings {
-    pub controllers: Option<Vec<Principal>>,
-}
-
 pub async fn new() -> Result<Principal, String> {
     open_call("create_canister");
-    let result = call_with_payment(
-        Principal::management_canister(),
-        "create_canister",
-        (CanisterSettings { controllers: None },),
+    let result = create_canister(
+        CreateCanisterArgument { settings: None },
         CYCLES_FOR_NEW_CANISTER,
     )
     .await;
     close_call("create_canister");
 
-    let (response,): (CanisterId,) =
+    let (response,): (CanisterIdRecord,) =
         result.map_err(|err| format!("couldn't create a new canister: {:?}", err))?;
 
     Ok(response.canister_id)
 }
 
-#[derive(CandidType, Deserialize)]
-pub enum CanisterInstallMode {
-    #[serde(rename = "install")]
-    Install,
-    #[serde(rename = "reinstall")]
-    Reinstall,
-    #[serde(rename = "upgrade")]
-    Upgrade,
-}
+pub async fn status(canister_id: Principal) -> Result<CanisterStatusResponse, String> {
+    open_call("status");
+    let response = canister_status(CanisterIdRecord { canister_id }).await;
+    close_call("status");
 
-#[derive(Deserialize, CandidType)]
-pub struct Settings {
-    pub controllers: Vec<Principal>,
-}
-
-#[derive(Deserialize, CandidType)]
-pub struct StatusCallResult {
-    pub settings: Settings,
-    pub module_hash: Option<Vec<u8>>,
-}
-
-pub async fn settings(canister_id: Principal) -> Result<StatusCallResult, String> {
-    let result = management_canister_call(canister_id, "canister_status").await;
-    let (result,): (StatusCallResult,) =
-        result.map_err(|err| format!("couldn't get canister status: {:?}", err))?;
-    Ok(result)
-}
-
-pub async fn management_canister_call<T: for<'a> ArgumentDecoder<'a>>(
-    canister_id: Principal,
-    method: &str,
-) -> Result<T, (RejectionCode, String)> {
-    #[derive(CandidType)]
-    struct In {
-        canister_id: Principal,
-    }
-
-    open_call(method);
-    let result = call(
-        Principal::management_canister(),
-        method,
-        (In { canister_id },),
-    )
-    .await;
-    close_call(method);
-    result
-}
-
-#[derive(CandidType)]
-struct InstallCodeArgs<'a> {
-    pub mode: CanisterInstallMode,
-    pub canister_id: Principal,
-    pub wasm_module: &'a [u8],
-    pub arg: Vec<u8>,
+    response
+        .map(|(val,)| val)
+        .map_err(|err| format!("couldn't get canister status: {:?}", err))
 }
 
 pub async fn install(
@@ -152,25 +97,13 @@ pub async fn install(
     wasm_module: &[u8],
     mode: CanisterInstallMode,
 ) -> Result<(), String> {
-    #[derive(CandidType)]
-    struct InstallCodeArgs<'a> {
-        pub mode: CanisterInstallMode,
-        pub canister_id: Principal,
-        pub wasm_module: &'a [u8],
-        pub arg: Vec<u8>,
-    }
-
     open_call("install_code");
-    let result = call(
-        Principal::management_canister(),
-        "install_code",
-        (InstallCodeArgs {
-            mode,
-            canister_id,
-            wasm_module,
-            arg: ic_cdk::api::id().as_slice().to_vec(),
-        },),
-    )
+    let result = install_code(InstallCodeArgument {
+        mode,
+        canister_id,
+        wasm_module: wasm_module.to_vec(),
+        arg: ic_cdk::api::id().as_slice().to_vec(),
+    })
     .await;
     close_call("install_code");
 
@@ -200,29 +133,23 @@ pub fn upgrade_main_canister(logger: &mut Logger, wasm_module: &[u8], force: boo
     notify(
         Principal::management_canister(),
         "install_code",
-        (InstallCodeArgs {
+        (InstallCodeArgument {
             mode: CanisterInstallMode::Upgrade,
             canister_id: id(),
-            wasm_module,
+            wasm_module: wasm_module.to_vec(),
             arg: ic_cdk::api::id().as_slice().to_vec(),
         },),
     )
     .expect("self-upgrade failed");
 }
 
-pub async fn topup_with_cycles(canister_id: Principal, cycles: u64) -> Result<(), String> {
+pub async fn topup_with_cycles(canister_id: Principal, cycles: u128) -> Result<(), String> {
     #[derive(CandidType)]
     struct Args {
         pub canister_id: Principal,
     }
     open_call("deposit_cycles");
-    let result = call_with_payment(
-        Principal::management_canister(),
-        "deposit_cycles",
-        (Args { canister_id },),
-        cycles,
-    )
-    .await;
+    let result = deposit_cycles(CanisterIdRecord { canister_id }, cycles).await;
     close_call("deposit_cycles");
     result.map_err(|err| format!("couldn't deposit cycles: {:?}", err))?;
     Ok(())
@@ -233,7 +160,7 @@ pub async fn top_up(canister_id: Principal, min_cycle_balance: u64) -> Result<bo
         .await
         .map_err(|err| format!("couldn't call child canister: {:?}", err))?;
     if response < min_cycle_balance {
-        topup_with_cycles(canister_id, min_cycle_balance)
+        topup_with_cycles(canister_id, min_cycle_balance as u128)
             .await
             .map_err(|err| format!("failed to top up canister {}: {:?}", canister_id, err))?;
         return Ok(true);

--- a/src/backend/env/config.rs
+++ b/src/backend/env/config.rs
@@ -67,9 +67,7 @@ pub struct Config {
 
     pub realm_revenue_percentage: u32,
 
-    pub main_canister_min_cycle_balance: u64,
-
-    pub child_canister_min_cycle_balance: u64,
+    pub canister_survival_period_days: u64,
 
     pub max_bucket_size: u64,
 
@@ -235,15 +233,7 @@ pub const CONFIG: &Config = &Config {
 
     maximum_supply: 100_000_000,
 
-    #[cfg(not(feature = "staging"))]
-    main_canister_min_cycle_balance: 10 * ICP_CYCLES_PER_XDR,
-    #[cfg(not(feature = "staging"))]
-    child_canister_min_cycle_balance: 10 * ICP_CYCLES_PER_XDR,
-
-    #[cfg(feature = "staging")]
-    main_canister_min_cycle_balance: 2 * ICP_CYCLES_PER_XDR,
-    #[cfg(feature = "staging")]
-    child_canister_min_cycle_balance: 2 * ICP_CYCLES_PER_XDR,
+    canister_survival_period_days: 90,
 
     num_hot_posts: 10000,
 

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1046,8 +1046,6 @@ impl State {
                 if cycles / cycles_per_day < CONFIG.canister_survival_period_days {
                     let xdrs =
                         CONFIG.canister_survival_period_days * cycles_per_day / ICP_CYCLES_PER_XDR;
-                    // subtract weekly burned credits to reduce the revenue
-                    mutate(|state| state.spend(xdrs * 1000, "canister top up"));
                     match invoices::topup_with_icp(&api::id(), xdrs).await {
                         Err(err) => mutate(|state| {
                             state.critical(format!(
@@ -1056,7 +1054,9 @@ impl State {
                     err
                 ))
                         }),
-                        Ok(_credits) => mutate(|state| {
+                        Ok(_) => mutate(|state| {
+                            // subtract weekly burned credits to reduce the revenue
+                            state.spend(xdrs * 1000, "main canister top up");
                             state.logger.debug(format!(
                         "The main canister was topped up with credits (balance was `{}`, now `{}`).",
                         cycles,

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -366,7 +366,7 @@ impl State {
     }
 
     pub async fn finalize_upgrade() {
-        let current_hash = canisters::settings(id())
+        let current_hash = canisters::status(id())
             .await
             .ok()
             .and_then(|s| s.module_hash.map(hex::encode))
@@ -1041,8 +1041,7 @@ impl State {
 
         // top up the main canister
         let balance = canister_balance();
-        let target_balance = CONFIG.main_canister_min_cycle_balance
-            + children.len() as u64 * CONFIG.child_canister_min_cycle_balance;
+        let target_balance = CONFIG.main_canister_min_cycle_balance;
         if balance < target_balance {
             let xdrs = target_balance / ICP_CYCLES_PER_XDR;
             // subtract weekly burned credits to reduce the revenue

--- a/src/backend/env/storage.rs
+++ b/src/backend/env/storage.rs
@@ -1,8 +1,9 @@
 use crate::{
-    canisters::{self, CanisterInstallMode},
+    canisters::{self},
     mutate, read,
 };
 use candid::Principal;
+use ic_cdk::api::management_canister::main::CanisterInstallMode;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -90,7 +90,9 @@ fn sync_post_upgrade_fixtures() {
 }
 
 #[allow(clippy::all)]
-async fn async_post_upgrade_fixtures() {}
+async fn async_post_upgrade_fixtures() {
+    storage::upgrade_buckets().await;
+}
 
 /*
  * UPDATES

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -79,7 +79,15 @@ fn post_upgrade() {
 }
 
 #[allow(clippy::all)]
-fn sync_post_upgrade_fixtures() {}
+fn sync_post_upgrade_fixtures() {
+    mutate(|state| {
+        // Reset Keyda's report again (the last time missed `post_report`, see https://taggr.link/#/post/1273612)
+        if let Some(user) = state.users.get_mut(&3570) {
+            user.post_reports.clear();
+            user.report.take();
+        }
+    })
+}
 
 #[allow(clippy::all)]
 async fn async_post_upgrade_fixtures() {}

--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Content } from "./content";
+import { CUT, Content } from "./content";
 import {
     bigScreen,
     blobToUrl,
@@ -63,6 +63,7 @@ export const Form = ({
     const [value, setValue] = React.useState("");
     const [realm, setRealm] = React.useState(realmArg);
     const [submitting, setSubmitting] = React.useState(false);
+    const [overflowBanner, setOverflowBanner] = React.useState(false);
     const [lines, setLines] = React.useState(3);
     const [totalCosts, setTotalCosts] = React.useState(0);
     const [proposalType, setProposalType] = React.useState<ProposalType>(
@@ -266,7 +267,17 @@ export const Form = ({
         const suggestedRealms = suggestTokens(cursor, value, realms, "/");
         setSuggestedRealms(suggestedRealms);
         setChoresTimer(
-            setTimeout(() => localStorage.setItem(draftKey, value), 1500),
+            setTimeout(() => {
+                localStorage.setItem(draftKey, value);
+                const article: any = articleRef.current;
+                // Show a banner notifying about a too long post if no cut is used.
+                setOverflowBanner(
+                    article &&
+                        !value.includes(CUT) &&
+                        article.clientHeight > 0 &&
+                        article.scrollHeight > article.clientHeight,
+                );
+            }, 1500),
         );
         if (writingCallback) writingCallback(value);
     };
@@ -330,7 +341,7 @@ export const Form = ({
 
     React.useEffect(() => setFocus(), [showTextField, focus]);
 
-    const ref = React.useRef();
+    const articleRef = React.useRef();
 
     const self = document.getElementById(id);
     if (self && self.clientHeight < self.scrollHeight) setLines(lines + 2);
@@ -355,8 +366,8 @@ export const Form = ({
 
     const preview = (
         <article
-            ref={ref as unknown as any}
-            className={`bottom_spaced max_width_col ${
+            ref={articleRef as unknown as any}
+            className={`bottom_spaced preview max_width_col ${
                 postId == null ? "prime" : ""
             } framed`}
         >
@@ -422,6 +433,13 @@ export const Form = ({
                 <div className="banner vertically_spaced">
                     You are low on credits! Please mint credits in your wallet
                     to create this post.
+                </div>
+            )}
+            {overflowBanner && (
+                <div className="banner vertically_spaced">
+                    Your post is too long and will be cut when displayed in
+                    feeds! Please, use three empty lines to separate the
+                    introductory part from the rest of the content.
                 </div>
             )}
             {showTextField && !tooExpensive && (

--- a/src/frontend/src/new.tsx
+++ b/src/frontend/src/new.tsx
@@ -83,8 +83,8 @@ export const PostSubmissionForm = ({
                     in the corresponding tag-feed.
                 </li>
                 <li>
-                    For long posts, use three empty lines to separate the upper
-                    part of the post from the long body.
+                    For long posts, use three empty lines to separate the
+                    introductory part from the rest of the content.
                 </li>
                 <li>You can drag and drop images into the text area.</li>
                 <li>

--- a/src/frontend/src/post.tsx
+++ b/src/frontend/src/post.tsx
@@ -43,7 +43,7 @@ import {
     More,
 } from "./icons";
 import { ProposalView } from "./proposals";
-import { BlogTitle, Feature, Post, PostId, Realm, UserId } from "./types";
+import { Feature, Post, PostId, Realm, UserId } from "./types";
 import { MAINNET_MODE } from "./env";
 import { UserLink, UserList, populateUserNameCache } from "./user_resolve";
 
@@ -317,14 +317,16 @@ export const PostView = ({
                     </div>
                 )}
                 {!isNSFW && (
-                    <PostContent
-                        blogTitle={blogTitle}
-                        expanded={expanded}
-                        value={body}
-                        primeMode={isRoot(post) && !repost}
-                        urls={urls}
-                        goInside={goInside}
-                    />
+                    <article onClick={goInside}>
+                        <Content
+                            blogTitle={blogTitle}
+                            post={true}
+                            value={body}
+                            collapse={!expanded}
+                            primeMode={isRoot(post) && !repost}
+                            urls={urls}
+                        />
+                    </article>
                 )}
                 {showExtension && post.extension == "Feature" && (
                     <FeatureView id={post.id} />
@@ -434,74 +436,6 @@ const Comments = ({
                 </li>
             ))}
         </ul>
-    );
-};
-
-const PostContent = ({
-    goInside,
-    expanded,
-    blogTitle,
-    primeMode,
-    urls,
-    value,
-}: {
-    blogTitle?: BlogTitle;
-    primeMode: boolean;
-    expanded?: boolean;
-    goInside: any;
-    urls: { [id: string]: string };
-    value: string;
-}) => {
-    // All posts in non-prime mode should be collapsed if they are too long. The problem with
-    // deterministic collapsing is that the height of a DOM element is only known when this element
-    // is rendered. The rendering itself is asynchronous and transparent to the React framework.
-    // So there is a fundamental limitation to how much we can do from inside the React itself.
-    //
-    // To work around this limitation, we do the following. First, we render the container of
-    // the post and then, once we have the link to the DOM element, we make 10 attempts lasting at
-    // most 1s in total, where we try to measure the height of the container and the height of its
-    // content. If the content is longer that the container height, we mark the post as overflowing
-    // which displays the post with a gradient below.
-    //
-    // In the worst case (if the content takes longer than 1s to render), this post will be cut but
-    // not display the gradient.
-    //
-    // The reason why it needs to be delayed and implemented asynchronously is that
-    // the post content itself is rendered asynchronously as well: it takes non-zero time to render
-    // long posts, let alone to load and render an image. The markdown library we use does not provide
-    // any reliable callback mechanism notofying about the end of the rendering.
-    const [renderingAttempts, setRenderingAttempts] = React.useState(
-        expanded ? 0 : 15,
-    );
-    const refArticle = React.useRef();
-
-    React.useEffect(() => {
-        if (renderingAttempts <= 0) return;
-        setTimeout(() => {
-            const article: any = refArticle.current;
-            // The parent container or the child content was not rendered yet.
-            if (!article || article.clientHeight == 0) {
-                setRenderingAttempts(renderingAttempts - 1);
-                return;
-            }
-            if (article.scrollHeight > article.clientHeight) {
-                article.classList.add("overflowing");
-            }
-            setRenderingAttempts(0);
-        }, 100);
-    }, [renderingAttempts]);
-
-    return (
-        <article ref={refArticle as unknown as any} onClick={goInside}>
-            <Content
-                blogTitle={blogTitle}
-                post={true}
-                value={value}
-                collapse={!expanded}
-                primeMode={primeMode}
-                urls={urls}
-            />
-        </article>
     );
 };
 

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -221,8 +221,9 @@ article {
     overflow: hidden;
 }
 
-.feed_item article {
-    max-height: 90vh;
+.feed_item article,
+article.preview {
+    max-height: 100vh;
     position: relative;
 }
 
@@ -232,20 +233,6 @@ article {
 
 .prime .post_extension article {
     max-height: 150vh;
-}
-
-.post_extension article.overflowing::after {
-    background: linear-gradient(to top, $light_background, transparent);
-}
-
-article.overflowing::after {
-    content: "";
-    height: 50px;
-    width: 100%;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    background: linear-gradient(to top, $background, transparent);
 }
 
 .feed_item {


### PR DESCRIPTION
- Refactor canister interaction code and use more helper functions from the official CDK.
- Fix the canister top up: instead of keeping a fixed minimal amount of cycles (this is wrong as the minimal amount grows with the canister size), use the number of days left for a canister and  always top up when only 3 months of cycles are left.
- Remove the automated post cutting and introduce a hard cut of posts longer than one screen height. Additionally, warn users during post editing if a post is too long and no cut was used (3 empty lines).