### PR TITLE
feat: token auctions

### DIFF
--- a/src/backend/env/auction.rs
+++ b/src/backend/env/auction.rs
@@ -1,0 +1,393 @@
+use std::collections::BTreeSet;
+
+use candid::Principal;
+use ic_ledger_types::{
+    AccountIdentifier, Memo, Subaccount, Tokens, DEFAULT_FEE, DEFAULT_SUBACCOUNT,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    env::invoices::{self},
+    id, mutate, read, time,
+};
+
+use super::{
+    invoices::{main_account, principal_to_subaccount},
+    token::Token,
+    user::UserId,
+    State, Time,
+};
+
+pub const AUCTION_ICP_SUBACCOUNT: [u8; 32] = [
+    0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+];
+
+pub fn auction_account() -> AccountIdentifier {
+    AccountIdentifier::new(&id(), &Subaccount(AUCTION_ICP_SUBACCOUNT))
+}
+
+#[derive(Clone, Eq, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Bid {
+    pub user: UserId,
+    pub amount: Token,
+    // e8s for 1 TAGGR cent
+    pub e8s_per_token: u64,
+    timestamp: Time,
+}
+
+impl PartialOrd for Bid {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Bid {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.e8s_per_token != other.e8s_per_token {
+            // prioritize higher bids
+            return self.e8s_per_token.cmp(&other.e8s_per_token);
+        }
+        if self.timestamp != other.timestamp {
+            // prioritize older bids
+            return other.timestamp.cmp(&self.timestamp);
+        }
+        if self.amount != other.amount {
+            // prioritize larger bids
+            return self.amount.cmp(&other.amount);
+        }
+        self.user.cmp(&other.user)
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct Auction {
+    pub amount: Token,
+    bids: BTreeSet<Bid>,
+}
+
+impl Auction {
+    /// Checks if there is a sell out.
+    pub fn sell_out(&self) -> bool {
+        self.bids.iter().map(|bid| bid.amount).sum::<u64>() >= self.amount
+    }
+
+    /// Returns the highest bids if they form a sell out.
+    pub fn get_bids(&mut self) -> Vec<Bid> {
+        if !self.sell_out() {
+            return Default::default();
+        }
+        let mut amount = self.amount;
+        let mut bids = Vec::default();
+
+        while amount > 0 {
+            let Some(bid) = self.bids.pop_last() else {
+                break;
+            };
+            let eff_amount = bid.amount.min(amount);
+            bids.push(Bid {
+                user: bid.user,
+                amount: eff_amount,
+                e8s_per_token: bid.e8s_per_token,
+                timestamp: bid.timestamp,
+            });
+            // if the bid was larger than tokens left, create a leftover bid
+            if eff_amount < bid.amount {
+                self.bids.insert(Bid {
+                    user: bid.user,
+                    amount: bid.amount - eff_amount,
+                    e8s_per_token: bid.e8s_per_token,
+                    timestamp: bid.timestamp,
+                });
+            }
+            amount = amount.saturating_sub(eff_amount);
+        }
+
+        bids
+    }
+}
+
+/// Cancels user's bid and returns the funds to user wallet.
+pub async fn cancel_bid(principal: Principal) -> Result<u64, String> {
+    let bid = mutate(|state| remove_bid(state, principal))?;
+
+    let user_account = read(|state| {
+        let user_principal = state
+            .principal_to_user(principal)
+            .expect("no user found")
+            .principal;
+        AccountIdentifier::new(&user_principal, &DEFAULT_SUBACCOUNT)
+    });
+
+    let funds = bid
+        .amount
+        .checked_mul(bid.e8s_per_token)
+        .expect("overflow")
+        .checked_sub(DEFAULT_FEE.e8s())
+        .expect("nothing to refund");
+
+    invoices::transfer(
+        user_account,
+        Tokens::from_e8s(funds),
+        Memo(727),
+        Some(Subaccount(AUCTION_ICP_SUBACCOUNT)),
+    )
+    .await
+    .map_err(|err| {
+        let msg = format!("couldn't withdraw funds from bid {:?}: {}", bid, err);
+        mutate(|state| state.logger.error(&msg));
+        msg
+    })
+}
+
+fn remove_bid(state: &mut State, principal: Principal) -> Result<Bid, String> {
+    let user_id = state
+        .principal_to_user(principal)
+        .ok_or("no user found")?
+        .id;
+
+    let bid = state
+        .auction
+        .bids
+        .iter()
+        .find(|bid| bid.user == user_id)
+        .ok_or("no bids found")?
+        .clone();
+    state.auction.bids.retain(|bid| bid.user != user_id);
+
+    Ok(bid)
+}
+
+fn has_bid(state: &State, principal: Principal) -> bool {
+    state
+        .principal_to_user(principal)
+        .map(|user| state.auction.bids.iter().any(|bid| bid.user == user.id))
+        .unwrap_or_default()
+}
+
+/// Creates a new user bid. Requires a transfer to the user subaccount before.
+pub async fn create_bid(
+    principal: Principal,
+    amount: Token,
+    e8s_per_token: u64,
+) -> Result<(), String> {
+    // cancel existing bid if necessary
+    if read(|state| has_bid(state, principal)) {
+        cancel_bid(principal).await?;
+    }
+
+    // deposit funds for the bid
+    invoices::transfer(
+        auction_account(),
+        Tokens::from_e8s(amount.checked_mul(e8s_per_token).expect("overflow")),
+        Memo(717),
+        Some(principal_to_subaccount(&principal)),
+    )
+    .await
+    .map_err(|err| format!("couldn't deposit funds: {}", err))?;
+
+    mutate(|state| add_bid(state, principal, amount, e8s_per_token, time()))
+}
+
+// Adds user's bid. Expects no bids to exist from the same user.
+fn add_bid(
+    state: &mut State,
+    principal: Principal,
+    amount: Token,
+    e8s_per_token: u64,
+    timestamp: Time,
+) -> Result<(), String> {
+    if amount == 0 {
+        return Err("invalid amount".into());
+    }
+    let user_id = state
+        .principal_to_user(principal)
+        .ok_or("no user found")?
+        .id;
+
+    assert!(
+        !state.auction.bids.iter().any(|bid| bid.user == user_id),
+        "no bids exist for the user"
+    );
+
+    state.auction.bids.insert(Bid {
+        user: user_id,
+        amount,
+        e8s_per_token,
+        timestamp,
+    });
+    Ok(())
+}
+
+/// When the auction was closed successfully, moves funds to the treasury.
+pub async fn move_to_treasury(amount: u64) -> Result<u64, String> {
+    invoices::transfer(
+        main_account(),
+        Tokens::from_e8s(amount),
+        Memo(737),
+        Some(Subaccount(AUCTION_ICP_SUBACCOUNT)),
+    )
+    .await
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use crate::{
+        env::{
+            auction::Auction,
+            tests::{create_user, pr},
+        },
+        mutate,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_auction() {
+        mutate(|state| {
+            for i in 0..3 {
+                create_user(state, pr(i));
+            }
+
+            state.auction = Auction {
+                amount: 15000,
+                bids: Default::default(),
+            };
+
+            // wrong amount
+            assert!(add_bid(state, pr(0), 0, 1, 0).is_err());
+
+            let one_icp = 100000000;
+
+            // Bid 1 ICP for 100 TAGGR
+            add_bid(state, pr(0), 10000, one_icp, 0).unwrap();
+            assert!(!state.auction.sell_out());
+
+            // Bid 2 ICP for 30 TAGGR
+            add_bid(state, pr(1), 3000, 2 * one_icp, 0).unwrap();
+            assert!(!state.auction.sell_out());
+
+            // Bid 3 ICP for 22 TAGGR
+            add_bid(state, pr(2), 2200, 3 * one_icp, 0).unwrap();
+            assert!(state.auction.sell_out());
+
+            // make sure we order correctly
+            assert_eq!(
+                state
+                    .auction
+                    .bids
+                    .iter()
+                    .map(|bid| bid.user)
+                    .collect::<Vec<_>>(),
+                vec![0, 1, 2]
+            );
+
+            // Now all users except the first one get what they bid for.
+            // The first one (offering the lowest price) gets the left overs (two tokens less).
+            let bids = state.auction.get_bids();
+
+            assert_eq!(
+                bids,
+                vec![
+                    Bid {
+                        user: 2,
+                        amount: 2200,
+                        e8s_per_token: 3 * one_icp,
+                        timestamp: 0
+                    },
+                    Bid {
+                        user: 1,
+                        amount: 3000,
+                        e8s_per_token: 2 * one_icp,
+                        timestamp: 0
+                    },
+                    Bid {
+                        user: 0,
+                        amount: 10000 - 200,
+                        e8s_per_token: one_icp,
+                        timestamp: 0
+                    },
+                ]
+            );
+
+            // make sure those who didn't get tokens, still have their bids
+            assert_eq!(
+                state.auction.bids.iter().cloned().collect::<Vec<_>>(),
+                vec![Bid {
+                    user: 0,
+                    amount: 200,
+                    e8s_per_token: one_icp,
+                    timestamp: 0
+                }]
+            );
+        })
+    }
+
+    #[test]
+    fn test_bid_orders() {
+        mutate(|state| {
+            for i in 0..3 {
+                create_user(state, pr(i));
+            }
+
+            state.auction = Auction {
+                amount: 15000,
+                bids: Default::default(),
+            };
+
+            let one_icp = 100000000;
+
+            // Bid 1 ICP for 100 TAGGR
+            add_bid(state, pr(0), 10000, one_icp, 0).unwrap();
+
+            // Bid 1 ICP for 200 TAGGR but later
+            add_bid(state, pr(1), 20000, one_icp, 1).unwrap();
+
+            // make sure the last item is the older one even though they offer the same price
+            assert_eq!(
+                state.auction.bids.iter().cloned().collect::<Vec<_>>(),
+                vec![
+                    Bid {
+                        user: 1,
+                        amount: 20000,
+                        e8s_per_token: one_icp,
+                        timestamp: 1
+                    },
+                    Bid {
+                        user: 0,
+                        amount: 10000,
+                        e8s_per_token: one_icp,
+                        timestamp: 0
+                    },
+                ]
+            );
+
+            // cancel previous bids
+            state.auction.bids.clear();
+
+            // Bid 1 ICP for 111 tokens
+            add_bid(state, pr(0), 111, one_icp, 0).unwrap();
+
+            // Bid 1 ICP for 222 tokens at the same time
+            add_bid(state, pr(1), 222, one_icp, 0).unwrap();
+
+            // make sure the last item is the one with larger amount
+            assert_eq!(
+                state.auction.bids.iter().cloned().collect::<Vec<_>>(),
+                vec![
+                    Bid {
+                        user: 0,
+                        amount: 111,
+                        e8s_per_token: one_icp,
+                        timestamp: 0
+                    },
+                    Bid {
+                        user: 1,
+                        amount: 222,
+                        e8s_per_token: one_icp,
+                        timestamp: 0
+                    },
+                ]
+            );
+        });
+    }
+}

--- a/src/backend/env/config.rs
+++ b/src/backend/env/config.rs
@@ -165,7 +165,7 @@ pub const CONFIG: &Config = &Config {
     logo: include_str!("../../frontend/assets/logo.min.svg"),
     staging: "e4i5g-biaaa-aaaao-ai7ja-cai.icp0.io",
 
-    weekly_auction_size_tokens: 15000,
+    weekly_auction_size_tokens: 1500,
 
     #[cfg(not(feature = "staging"))]
     token_symbol: "TAGGR",

--- a/src/backend/env/config.rs
+++ b/src/backend/env/config.rs
@@ -28,6 +28,8 @@ pub struct Config {
     // temporary measure to slow down the minting until the DAO agrees on a better approach.
     pub difficulty_amplification: u64,
 
+    pub weekly_auction_size_tokens: Token,
+
     pub max_age_hot_post_days: u64,
 
     pub downvote_counting_period_days: u64,
@@ -162,6 +164,8 @@ pub const CONFIG: &Config = &Config {
     ],
     logo: include_str!("../../frontend/assets/logo.min.svg"),
     staging: "e4i5g-biaaa-aaaao-ai7ja-cai.icp0.io",
+
+    weekly_auction_size_tokens: 15000,
 
     #[cfg(not(feature = "staging"))]
     token_symbol: "TAGGR",

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1,3 +1,4 @@
+use self::auction::Auction;
 use self::canisters::{icrc_transfer, upgrade_main_canister, NNSVote};
 use self::invoices::{Invoice, USER_ICP_SUBACCOUNT};
 use self::post::{archive_cold_posts, Extension, Poll, Post, PostId};
@@ -16,7 +17,9 @@ use config::{CONFIG, ICP_CYCLES_PER_XDR};
 use ic_cdk::api::performance_counter;
 use ic_cdk::api::stable::stable64_size;
 use ic_cdk::api::{self, canister_balance};
-use ic_ledger_types::{AccountIdentifier, Tokens, DEFAULT_SUBACCOUNT, MAINNET_LEDGER_CANISTER_ID};
+use ic_ledger_types::{
+    AccountIdentifier, Tokens, DEFAULT_FEE, DEFAULT_SUBACCOUNT, MAINNET_LEDGER_CANISTER_ID,
+};
 use invoices::Invoices;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -25,6 +28,7 @@ use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use user::{User, UserId};
 
+pub mod auction;
 pub mod canisters;
 pub mod config;
 pub mod features;
@@ -141,6 +145,9 @@ pub struct Summary {
 
 #[derive(Default, Serialize, Deserialize)]
 pub struct State {
+    #[serde(default)]
+    pub auction: Auction,
+
     pub burned_cycles: i64,
     pub posts: BTreeMap<PostId, Post>,
     pub users: BTreeMap<UserId, User>,
@@ -1273,7 +1280,7 @@ impl State {
         }
 
         if summary.items.is_empty() {
-            self.logger.info("no tokens were minted".to_string());
+            self.logger.info("No tokens were minted".to_string());
         } else {
             summary.description = format!(
                 "{} minted `{}` ${} tokens 💎 from the earned reward at the ratio `{}:1`",
@@ -1680,6 +1687,15 @@ impl State {
             state.mint();
             state.minting_mode = false;
         });
+
+        let minting_price = State::close_auction().await;
+        mutate(|state| {
+            state.logger.info(format!(
+                "Established minting price: `{}` e8s per token",
+                minting_price
+            ))
+        });
+
         State::distribute_icp().await;
         mutate(|state| {
             for summary in &state.distribution_reports {
@@ -1692,6 +1708,67 @@ impl State {
             state.clean_up(now);
             state.charge_for_inactivity(now);
         });
+    }
+
+    // Checks if we could collect enough bids to close the auction.
+    // If yes, mints the requested amount of tokens for each bidder and moves all funds to
+    // treasury, converting them to revenue.
+    async fn close_auction() -> u64 {
+        let (bids, revenue, minting_price) = mutate(|state| {
+            let bids = state.auction.get_bids();
+            if bids.is_empty() {
+                state.logger.info("Auction skipped: not enough bids");
+                return (bids, 0, 0);
+            }
+
+            let icp_fee = DEFAULT_FEE.e8s();
+            let mut revenue = 0;
+
+            state.minting_mode = true;
+            for bid in &bids {
+                let principal = state.users.get(&bid.user).expect("no user found").principal;
+                token::mint(state, account(principal), bid.amount);
+                revenue += bid
+                    .amount
+                    .checked_mul(bid.e8s_per_token)
+                    .expect("overflow")
+                    // subtract the fee because we do not charge it when a bid is created
+                    .checked_sub(icp_fee)
+                    .expect("underflow");
+            }
+            state.minting_mode = false;
+
+            // set token number for the next week
+            state.auction.amount = CONFIG.weekly_auction_size_tokens;
+
+            // subtract the fee because we will move it to the treasury
+            revenue = revenue.saturating_sub(icp_fee);
+            state.burned_cycles +=
+                (revenue / state.e8s_for_one_xdr * CONFIG.credits_per_xdr) as i64;
+
+            let minting_price = revenue / state.auction.amount;
+
+            (bids, revenue, minting_price)
+        });
+
+        if revenue == 0 {
+            return minting_price;
+        }
+
+        if let Err(err) = auction::move_to_treasury(revenue).await {
+            mutate(|state| {
+                state.logger.error(format!(
+                    "couldn't move funds from the auction to treasury: {}",
+                    err
+                ));
+                state
+                    .logger
+                    .error(format!("bids that were closed: {:?}", bids))
+            });
+            return 0;
+        }
+
+        minting_price
     }
 
     fn distribute_realm_revenue(&mut self, now: Time) {

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -1,7 +1,9 @@
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
 
-use crate::env::{proposals::Payload, token::Token, user::UserFilter};
+use crate::env::{
+    invoices::principal_to_subaccount, proposals::Payload, token::Token, user::UserFilter,
+};
 
 use super::*;
 use candid::Principal;
@@ -17,6 +19,7 @@ use ic_cdk::{
     caller,
 };
 use ic_cdk_macros::query;
+use ic_ledger_types::AccountIdentifier;
 use serde_bytes::ByteBuf;
 
 #[export_name = "canister_query check_invite"]
@@ -55,6 +58,17 @@ fn migration_pending() {
     read(|state| {
         reply(state.principal_change_requests.contains_key(&caller()));
     });
+}
+
+#[export_name = "canister_query auction"]
+fn auction() {
+    read(|state| {
+        reply((
+            &state.auction,
+            // user's canister subaccount for the ICP deposit
+            AccountIdentifier::new(&id(), &principal_to_subaccount(&caller())).to_string(),
+        ))
+    })
 }
 
 #[export_name = "canister_query features"]

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -79,7 +79,9 @@ fn post_upgrade() {
 }
 
 #[allow(clippy::all)]
-fn sync_post_upgrade_fixtures() {}
+fn sync_post_upgrade_fixtures() {
+    mutate(|state| state.auction.amount = CONFIG.weekly_auction_size_tokens)
+}
 
 #[allow(clippy::all)]
 async fn async_post_upgrade_fixtures() {
@@ -596,6 +598,19 @@ fn confirm_emergency_release() {
 #[update]
 fn force_emergency_upgrade() -> bool {
     mutate(|state| state.execute_pending_emergency_upgrade(true))
+}
+
+#[export_name = "canister_update create_bid"]
+fn create_bid() {
+    spawn(async {
+        let (amount, e8s_per_token): (u64, u64) = parse(&arg_data_raw());
+        reply(auction::create_bid(caller(), amount, e8s_per_token).await)
+    });
+}
+
+#[export_name = "canister_update cancel_bid"]
+fn cancel_bid() {
+    spawn(async { reply(auction::cancel_bid(caller()).await) });
 }
 
 fn caller() -> Principal {

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -419,7 +419,8 @@ export const timeAgo = (
     }
 };
 
-const tokenBase = () => Math.pow(10, window.backendCache.config.token_decimals);
+export const tokenBase = () =>
+    Math.pow(10, window.backendCache.config.token_decimals);
 
 export const tokenBalance = (balance: number) =>
     (balance / tokenBase()).toLocaleString();
@@ -430,6 +431,9 @@ export const icpCode = (e8s: BigInt, decimals?: number, units = true) => (
         {units && " ICP"}
     </code>
 );
+
+export const shortenAccount = (account: string) =>
+    `${account.slice(0, 6)}..${account.substr(account.length - 6)}`;
 
 export const tokens = (n: number, decimals: number, hideDecimals?: boolean) => {
     let base = Math.pow(10, decimals);
@@ -554,10 +558,7 @@ export const blobToUrl = (blob: ArrayBuffer) =>
 
 export const isRoot = (post: Post) => post.parent == null;
 
-export const token = (n: number) =>
-    Math.ceil(
-        n / Math.pow(10, window.backendCache.config.token_decimals),
-    ).toLocaleString();
+export const token = (n: number) => Math.ceil(n / tokenBase()).toLocaleString();
 
 export const IconToggleButton = ({
     title,

--- a/src/frontend/src/types.tsx
+++ b/src/frontend/src/types.tsx
@@ -10,6 +10,18 @@ export type ICP = {
     e8s: BigInt | number;
 };
 
+export type Bid = {
+    user: UserId;
+    amount: number;
+    e8s_per_token: number;
+    timestamp: number;
+};
+
+export type Auction = {
+    amount: number;
+    bids: Bid[];
+};
+
 export type Poll = {
     options: string[];
     votes: { [option: number]: UserId[] };

--- a/src/frontend/src/wallet.tsx
+++ b/src/frontend/src/wallet.tsx
@@ -1,4 +1,5 @@
 import {
+    shortenAccount,
     CopyToClipboard,
     HeadBar,
     Loading,
@@ -223,9 +224,6 @@ export const Welcome = () => {
         </>
     );
 };
-
-const shortenAccount = (account: string) =>
-    `${account.slice(0, 6)}..${account.substr(account.length - 6)}`;
 
 const shortenPrincipal = (principal: string) => {
     const parts = principal.split("-");


### PR DESCRIPTION
This PR introduces a weekly auction. We start with only 15 TAGGR. The tokens get minted to the auction winner if there is a sell out. The established market price is printed to the logs on the dashboard and is not used yet for anything.