### PR TITLE
fix: timers and preview window

### DIFF
--- a/src/frontend/src/form.tsx
+++ b/src/frontend/src/form.tsx
@@ -339,6 +339,20 @@ export const Form = ({
         setLines(effContent.split("\n").length + 2);
     }, [content]);
 
+    React.useEffect(() => {
+        const articleDOMelem = articleRef.current as unknown as HTMLElement;
+        const textareaDOMelem = textarea.current as unknown as HTMLElement;
+        if (
+            textareaDOMelem &&
+            articleDOMelem &&
+            articleDOMelem?.dataset?.synced != "true"
+        ) {
+            syncScrolling(articleDOMelem, textareaDOMelem);
+            syncScrolling(textareaDOMelem, articleDOMelem);
+            articleDOMelem.setAttribute("data-synced", "true");
+        }
+    }, [value]);
+
     React.useEffect(() => setFocus(), [showTextField, focus]);
 
     const articleRef = React.useRef();
@@ -875,3 +889,12 @@ const tableTemplate =
     "|-----|:---:|----:|\n" +
     "|  A  |  B  |  C  |\n" +
     "|  D  |  E  |  F  |\n";
+
+const syncScrolling = (elem1: HTMLElement, elem2: HTMLElement) => {
+    elem1.addEventListener("scroll", () => {
+        const scrollPercentage =
+            elem1.scrollTop / (elem1.scrollHeight - elem1.clientHeight);
+        elem2.scrollTop =
+            scrollPercentage * (elem2.scrollHeight - elem2.clientHeight);
+    });
+};

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -30,6 +30,15 @@ code {
         sans-serif;
 }
 
+article.preview,
+textarea {
+    max-height: 80vh;
+}
+
+article.preview {
+    overflow: auto;
+}
+
 .db_cell {
     display: flex;
     flex-direction: column;
@@ -221,8 +230,7 @@ article {
     overflow: hidden;
 }
 
-.feed_item article,
-article.preview {
+.feed_item article {
     max-height: 100vh;
     position: relative;
 }


### PR DESCRIPTION
Groups all infos about timers in one struct: the last execution time and pending status. This will now prevent overlapping routines even in cases where routines are overlapping.