### PR TITLE
Feature request: Invites revamp

### DIFF
--- a/src/backend/env/invite.rs
+++ b/src/backend/env/invite.rs
@@ -64,6 +64,11 @@ impl Invite {
                 ));
             }
 
+            // Protect against creating invite and setting to 0 without usage
+            if new_credits == 0 && self.joined_user_ids.is_empty() {
+                return Err("Cannot set credits to 0 as it has never been used".into());
+            }
+
             self.credits = new_credits;
         }
 

--- a/src/backend/env/invite.rs
+++ b/src/backend/env/invite.rs
@@ -32,13 +32,13 @@ impl Invite {
 
     pub fn consume(&mut self, joined_user_id: UserId) -> Result<(), String> {
         if self.joined_user_ids.contains(&joined_user_id) {
-            return Err("User already credited".into());
+            return Err("user already credited".into());
         }
 
         let new_credits = self
             .credits
             .checked_sub(self.credits_per_user)
-            .ok_or("Invite credits too low")?;
+            .ok_or("invite credits too low")?;
         self.credits = new_credits;
 
         self.joined_user_ids.insert(joined_user_id);
@@ -53,20 +53,20 @@ impl Invite {
         user_id: UserId,
     ) -> Result<(), String> {
         if self.inviter_user_id != user_id {
-            return Err("Owner does not match".into());
+            return Err("owner does not match".into());
         }
 
         if let Some(new_credits) = credits {
             if new_credits % self.credits_per_user != 0 {
                 return Err(format!(
-                    "Credits per user {} are not a multiple of new credits {}",
+                    "credits per user {} are not a multiple of new credits {}",
                     self.credits_per_user, new_credits,
                 ));
             }
 
             // Protect against creating invite and setting to 0 without usage
             if new_credits == 0 && self.joined_user_ids.is_empty() {
-                return Err("Cannot set credits to 0 as it has never been used".into());
+                return Err("cannot set credits to 0 as it has never been used".into());
             }
 
             self.credits = new_credits;
@@ -120,9 +120,9 @@ pub fn validate_user_invites_credits(
 
     let total_with_diff = total_invites_credits
         .checked_add(new_credits)
-        .ok_or("Invite credits overflow")?
+        .ok_or("invite credits overflow")?
         .checked_sub(old_credits.unwrap_or_default())
-        .ok_or("Invite credits overflow")?;
+        .ok_or("invite credits overflow")?;
 
     if total_with_diff > user.credits() {
         return Err(format!(

--- a/src/backend/env/invite.rs
+++ b/src/backend/env/invite.rs
@@ -1,3 +1,5 @@
+use crate::optional;
+
 use super::{user::UserId, Credits, Principal, RealmId, State, User};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -72,13 +74,7 @@ impl Invite {
             self.credits = new_credits;
         }
 
-        if let Some(id) = realm_id {
-            if id.is_empty() {
-                self.realm_id = None;
-            } else {
-                self.realm_id = Some(id);
-            }
-        }
+        self.realm_id = optional(realm_id.unwrap_or_default());
 
         Ok(())
     }

--- a/src/backend/env/invite.rs
+++ b/src/backend/env/invite.rs
@@ -1,0 +1,138 @@
+use super::{user::UserId, Credits, Principal, RealmId, State, User};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub struct Invite {
+    pub credits: Credits,
+    pub credits_per_user: Credits,
+    pub joined_user_ids: BTreeSet<UserId>,
+    pub realm_id: Option<RealmId>,
+    /// Owner id
+    pub user_id: UserId,
+}
+
+impl Invite {
+    pub fn new(
+        credits: Credits,
+        credits_per_user: Credits,
+        realm_id: Option<RealmId>,
+        user_id: UserId,
+    ) -> Self {
+        // Convert empty realm_id to None
+        let converted_relm_id: Option<RealmId> = realm_id.filter(|id| !id.is_empty());
+
+        Self {
+            credits,
+            credits_per_user,
+            joined_user_ids: BTreeSet::new(),
+            realm_id: converted_relm_id,
+            user_id,
+        }
+    }
+
+    pub fn consume(&mut self, joined_user_id: UserId) -> Result<(), String> {
+        let new_credits = self
+            .credits
+            .checked_sub(self.credits_per_user)
+            .ok_or("Invite credits too low")?;
+        self.credits = new_credits;
+
+        if self.joined_user_ids.contains(&joined_user_id) {
+            return Err("User already credited".into());
+        }
+
+        self.joined_user_ids.insert(joined_user_id);
+
+        Ok(())
+    }
+
+    pub fn update(
+        &mut self,
+        credits: Option<Credits>,
+        realm_id: Option<RealmId>,
+        user_id: UserId,
+    ) -> Result<(), String> {
+        if self.user_id != user_id {
+            return Err("Owner does not match".into());
+        }
+
+        if let Some(new_credits) = credits {
+            self.credits = new_credits;
+        }
+
+        if let Some(id) = realm_id {
+            if id.is_empty() {
+                self.realm_id = None;
+            } else {
+                self.realm_id = Some(id);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn invites_by_principal(state: &State, principal: Principal) -> Vec<(String, Invite)> {
+    state
+        .principal_to_user(principal)
+        .map(|user| {
+            state
+                .invite_codes
+                .iter()
+                .filter(|(_, invite)| invite.user_id == user.id)
+                .map(|(code, invite)| (code.clone(), invite.clone()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+pub fn validate_user_invites_credits(
+    state: &State,
+    user: &User,
+    new_credits: Credits,
+    old_credits: Option<Credits>,
+) -> Result<(), String> {
+    if user.credits() < new_credits {
+        return Err("not enough credits".into());
+    }
+
+    let total_invites_credits: Credits = state
+        .invite_codes
+        .values()
+        .filter(|invite| invite.user_id == user.id)
+        .map(|invite| invite.credits)
+        .sum();
+
+    let total_with_diff = total_invites_credits
+        .checked_add(new_credits)
+        .ok_or("Invite credits overflow")?
+        .checked_sub(old_credits.unwrap_or_default());
+
+    match total_with_diff {
+        Some(total_with_diff) => {
+            if total_with_diff > user.credits() {
+                return Err(format!(
+                    "You don't have enough credits to support invites {} , {}",
+                    user.credits(),
+                    total_with_diff
+                ));
+            }
+        }
+        None => {
+            return Err("Invite credits overflow".into());
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_realm_id(state: &State, realm_id: Option<&RealmId>) -> Result<(), String> {
+    if let Some(id) = realm_id {
+        if !id.is_empty() && !state.realms.contains_key(id) {
+            return Err(format!("Realm {} not found", id.clone()));
+        };
+    }
+
+    Ok(())
+}

--- a/src/backend/env/invite.rs
+++ b/src/backend/env/invite.rs
@@ -38,7 +38,7 @@ impl Invite {
         let new_credits = self
             .credits
             .checked_sub(self.credits_per_user)
-            .ok_or("invite credits too low")?;
+            .expect("invite credits too low");
         self.credits = new_credits;
 
         self.joined_user_ids.insert(joined_user_id);

--- a/src/backend/env/invite.rs
+++ b/src/backend/env/invite.rs
@@ -79,10 +79,7 @@ impl Invite {
     }
 }
 
-pub fn invites_by_principal<'a>(
-    state: &'a State,
-    principal: Principal,
-) -> Vec<(&'a String, &'a Invite)> {
+pub fn invites_by_principal(state: &State, principal: Principal) -> Vec<(&String, &Invite)> {
     let invites = state
         .principal_to_user(principal)
         .ok_or("Principal not found")

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -4889,7 +4889,7 @@ pub(crate) mod tests {
             assert_eq!(new_balance, prev_balance);
             let invite = invite::invites_by_principal(state, principal);
             assert_eq!(invite.len(), 1);
-            let (code, Invite { credits, .. }) = invite.first().unwrap().clone();
+            let (code, Invite { credits, .. }) = *invite.first().unwrap();
             assert_eq!(*credits, 111);
             (id, code.to_string(), prev_balance)
         });
@@ -4907,7 +4907,7 @@ pub(crate) mod tests {
             let prev_balance = user.credits();
             assert_eq!(state.create_invite(principal, 222, None, None), Ok(()));
             let invites = invite::invites_by_principal(state, principal);
-            let (code, Invite { credits, .. }) = invites.first().unwrap().clone();
+            let (code, Invite { credits, .. }) = *invites.first().unwrap();
             assert_eq!(*credits, 222);
             (id, code.to_string(), prev_balance)
         });

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -4890,8 +4890,8 @@ pub(crate) mod tests {
             let invite = invite::invites_by_principal(state, principal);
             assert_eq!(invite.len(), 1);
             let (code, Invite { credits, .. }) = invite.first().unwrap().clone();
-            assert_eq!(credits, 111);
-            (id, code, prev_balance)
+            assert_eq!(*credits, 111);
+            (id, code.to_string(), prev_balance)
         });
 
         // use the invite
@@ -4908,8 +4908,8 @@ pub(crate) mod tests {
             assert_eq!(state.create_invite(principal, 222, None, None), Ok(()));
             let invites = invite::invites_by_principal(state, principal);
             let (code, Invite { credits, .. }) = invites.first().unwrap().clone();
-            assert_eq!(credits, 222);
-            (id, code, prev_balance)
+            assert_eq!(*credits, 222);
+            (id, code.to_string(), prev_balance)
         });
 
         let prev_revenue = read(|state| state.burned_cycles);
@@ -4942,7 +4942,7 @@ pub(crate) mod tests {
 
             let code = invite::invites_by_principal(state, principal)
                 .first()
-                .map(|(code, _)| code.clone())
+                .map(|(code, _)| code.to_string())
                 .unwrap();
 
             code
@@ -4951,7 +4951,7 @@ pub(crate) mod tests {
         // New user should be joined to realm
         let new_principal = pr(5);
         assert_eq!(
-            State::create_user(new_principal, "name".to_string(), Some(invite_code.clone())).await,
+            State::create_user(new_principal, "name".to_string(), Some(invite_code)).await,
             Ok(Some(realm_id.clone()))
         );
         read(|state| {

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -3133,6 +3133,7 @@ pub fn display_tokens(amount: u64, decimals: u32) -> String {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use invite::tests::create_invite_with_realm;
     use post::Post;
 
     pub fn pr(n: usize) -> Principal {
@@ -4933,25 +4934,7 @@ pub(crate) mod tests {
     #[actix_rt::test]
     async fn test_invites_with_realm() {
         let principal = pr(4);
-        let realm_id = "realm-invite-test".to_string();
-        let invite_code = mutate(|state| {
-            // Create user with 2000 credits
-            create_user_with_credits(state, principal, 2000);
-
-            let _ = create_realm(state, principal, realm_id.clone());
-
-            assert_eq!(
-                state.create_invite(principal, 200, Some(50), Some(realm_id.clone())),
-                Ok(())
-            );
-
-            let code = invite::invites_by_principal(state, principal)
-                .last()
-                .map(|(code, _)| code.to_string())
-                .unwrap();
-
-            code
-        });
+        let (_, invite_code, realm_id) = mutate(|state| create_invite_with_realm(state, principal));
 
         // New user should be joined to realm
         let new_principal = pr(5);

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -4888,8 +4888,8 @@ pub(crate) mod tests {
             // no charging yet
             assert_eq!(new_balance, prev_balance);
             let invites = invite::invites_by_principal(state, principal);
-            assert_eq!(invites.len(), 1);
-            let (code, Invite { credits, .. }) = *invites.first().unwrap();
+            // assert_eq!(invites.count(), 1);
+            let (code, Invite { credits, .. }) = invites.last().unwrap();
             assert_eq!(*credits, 111);
             (id, code.to_string(), prev_balance)
         });
@@ -4907,7 +4907,7 @@ pub(crate) mod tests {
             let prev_balance = user.credits();
             assert_eq!(state.create_invite(principal, 222, None, None), Ok(()));
             let invites = invite::invites_by_principal(state, principal);
-            let (code, Invite { credits, .. }) = *invites.first().unwrap();
+            let (code, Invite { credits, .. }) = invites.last().unwrap();
             assert_eq!(*credits, 222);
             (id, code.to_string(), prev_balance)
         });
@@ -4941,7 +4941,7 @@ pub(crate) mod tests {
             );
 
             let code = invite::invites_by_principal(state, principal)
-                .first()
+                .last()
                 .map(|(code, _)| code.to_string())
                 .unwrap();
 
@@ -4959,8 +4959,8 @@ pub(crate) mod tests {
             assert_eq!(user.credits(), 50); // Invite gives 50 credits
             assert_eq!(user.realms.first().cloned(), Some(realm_id));
 
-            let (_, invite) = *invite::invites_by_principal(state, principal)
-                .first()
+            let (_, invite) = invite::invites_by_principal(state, principal)
+                .last()
                 .unwrap();
             assert_eq!(invite.credits, 150);
         });

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -4883,7 +4883,7 @@ pub(crate) mod tests {
             // use too many credits
             assert_eq!(
                 state.create_invite(principal, 1111, None, None),
-                Err("not enough credits".to_string())
+                Err("not enough credits available: 1000 (needed for invites: 1111)".into())
             );
 
             // use enough credits and make sure they were deducted

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -942,7 +942,7 @@ impl State {
                     state
                         .invite_codes
                         .get_mut(&code)
-                        .ok_or("Invite not found")?
+                        .ok_or("invite not found")?
                         .consume(new_user_id)?;
 
                     state
@@ -1021,7 +1021,7 @@ impl State {
     ) -> Result<(), String> {
         let credits_per_user = credits_per_user_opt.unwrap_or(credits);
         if credits % credits_per_user != 0 {
-            return Err("Credits per user are not a multiple of credits".into());
+            return Err("credits per user are not a multiple of credits".into());
         }
         let min_credits = CONFIG.min_credits_for_inviting;
         let user = self.principal_to_user(principal).ok_or("no user found")?;
@@ -1054,7 +1054,7 @@ impl State {
         realm_id: Option<RealmId>,
     ) -> Result<(), String> {
         if credits.is_none() && realm_id.is_none() {
-            return Err("Update is empty".into());
+            return Err("update is empty".into());
         }
         let user = self.principal_to_user(principal).ok_or("user not found")?;
         let user_id = user.id;
@@ -1067,14 +1067,14 @@ impl State {
         } = self
             .invite_codes
             .get(&invite_code)
-            .ok_or(format!("Invite '{}' not found", invite_code))?;
+            .ok_or(format!("invite '{}' not found", invite_code))?;
         if let Some(credits) = credits {
             invite::validate_user_invites_credits(self, user, credits, Some(*invite_credits))?;
         }
 
         self.invite_codes
             .get_mut(&invite_code)
-            .ok_or(format!("Invite '{}' not found", invite_code))?
+            .ok_or(format!("invite '{}' not found", invite_code))?
             .update(credits, realm_id, user_id)?;
         Ok(())
     }

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -3094,7 +3094,7 @@ impl State {
     fn validate_realm_id(&self, realm_id: Option<&RealmId>) -> Result<(), String> {
         if let Some(id) = realm_id {
             if !id.is_empty() && !self.realms.contains_key(id) {
-                return Err(format!("Realm {} not found", id.clone()));
+                return Err(format!("realm {} not found", id.clone()));
             };
         }
 

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -615,10 +615,10 @@ impl User {
     pub fn validate_send_credits(&self, state: &State) -> Result<(), String> {
         if let Some(invited_by) = self.invited_by {
             let invite = state.invite_codes.values().find(|invite| {
-                invited_by == invite.user_id && invite.joined_user_ids.contains(&self.id)
+                invited_by == invite.inviter_user_id && invite.joined_user_ids.contains(&self.id)
             });
             if let Some(invite) = invite {
-                if self.credits_burned() < invite.credits_per_user && self.credits() < 1000 {
+                if self.credits_burned() < invite.credits_per_user {
                     return Err("You are not allowed to send credits acquired in invite".into());
                 }
             }

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -620,7 +620,7 @@ impl User {
             });
             if let Some(invite) = invite {
                 if self.credits_burned() < invite.credits_per_user {
-                    return Err("You are not allowed to send credits acquired in invite".into());
+                    return Err("you are not allowed to send credits acquired in invite".into());
                 }
             }
         }

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -612,7 +612,9 @@ impl User {
         })
     }
 
-    /** Protect against invite phishing */
+    /// Protect against invite phishing
+    ///
+    /// TODO: credits_burned reset every week, think of better way
     pub fn validate_send_credits(&self, state: &State) -> Result<(), String> {
         if let Some(invited_by) = self.invited_by {
             let invite = state.invite_codes.values().find(|invite| {

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -611,6 +611,21 @@ impl User {
             Ok(())
         })
     }
+
+    pub fn validate_send_credits(&self, state: &State) -> Result<(), String> {
+        if let Some(invited_by) = self.invited_by {
+            let invite = state.invite_codes.values().find(|invite| {
+                invited_by == invite.user_id && invite.joined_user_ids.contains(&self.id)
+            });
+            if let Some(invite) = invite {
+                if self.credits_burned() < invite.credits_per_user && self.credits() < 1000 {
+                    return Err("You are not allowed to send credits acquired in invite".into());
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/backend/env/user.rs
+++ b/src/backend/env/user.rs
@@ -612,6 +612,7 @@ impl User {
         })
     }
 
+    /** Protect against invite phishing */
     pub fn validate_send_credits(&self, state: &State) -> Result<(), String> {
         if let Some(invited_by) = self.invited_by {
             let invite = state.invite_codes.values().find(|invite| {

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -23,7 +23,7 @@ use serde_bytes::ByteBuf;
 #[export_name = "canister_query check_invite"]
 fn check_invite() {
     let code: String = parse(&arg_data_raw());
-    read(|state| reply(state.invites.contains_key(&code)))
+    read(|state| reply(state.invite_codes.contains_key(&code)))
 }
 
 #[export_name = "canister_query migration_pending"]
@@ -334,7 +334,7 @@ fn tags_cost() {
 
 #[export_name = "canister_query invites"]
 fn invites() {
-    read(|state| reply(state.invites(caller())));
+    read(|state| reply(invite::invites_by_principal(state, caller())));
 }
 
 fn personal_filter(state: &State, user: Option<&User>, post: &Post) -> bool {

--- a/src/backend/queries.rs
+++ b/src/backend/queries.rs
@@ -334,7 +334,7 @@ fn tags_cost() {
 
 #[export_name = "canister_query invites"]
 fn invites() {
-    read(|state| reply(invite::invites_by_principal(state, caller())));
+    read(|state| reply(invite::invites_by_principal(state, caller()).collect::<Vec<_>>()));
 }
 
 fn personal_filter(state: &State, user: Option<&User>, post: &Post) -> bool {

--- a/src/backend/updates.rs
+++ b/src/backend/updates.rs
@@ -314,9 +314,8 @@ fn create_invite() {
 fn update_invite() {
     let (invite_code, credits, realm_id): (String, Option<Credits>, Option<RealmId>) =
         parse(&arg_data_raw());
-    let user_id = read(|state| state.principal_to_user(caller()).expect("no user found").id);
 
-    mutate(|state| reply(state.update_invite(user_id, invite_code, credits, realm_id)));
+    mutate(|state| reply(state.update_invite(caller(), invite_code, credits, realm_id)));
 }
 
 #[export_name = "canister_update delay_weekly_chores"]

--- a/src/frontend/src/common.tsx
+++ b/src/frontend/src/common.tsx
@@ -353,8 +353,10 @@ export const ButtonWithLoading = ({
             title={title}
             disabled={disabled || loading}
             className={`fat ${
-                loading ? classNameArg?.replaceAll("active", "") : classNameArg
-            }`}
+                loading || disabled
+                    ? classNameArg?.replaceAll("active", "")
+                    : classNameArg
+            } ${disabled ? "inactive" : ""}`}
             style={styleArg || null}
             data-testid={testId}
             onClick={async (e) => {

--- a/src/frontend/src/index.tsx
+++ b/src/frontend/src/index.tsx
@@ -120,7 +120,10 @@ const App = () => {
         ) : (
             <WelcomeInvited />
         );
-    } else if (handler == "wallet" || (window.principalId && !window.user)) {
+    } else if (
+        (handler == "wallet" || (window.principalId && !window.user)) &&
+        !window.realm
+    ) {
         content = <Welcome />;
     } else if (handler == "post") {
         const id = parseInt(param);

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -70,6 +70,7 @@ export const Invites = () => {
                 return;
             }
         }
+        await loadInvites();
     };
 
     const updateInvite = (
@@ -83,6 +84,7 @@ export const Invites = () => {
             // @ts-ignore
             invite[field] = value;
             invite.dirty = true;
+            setInvites([...invites]);
             return;
         }
     };
@@ -168,100 +170,106 @@ export const Invites = () => {
                 {invites.length > 0 && <h3>Your invites</h3>}
                 {busy && <Loading />}
                 {!busy && invites.length > 0 && (
-                    <table style={{ width: "100%" }}>
-                        <thead>
-                            <tr>
-                                <th align="left">
-                                    <Credits />
-                                </th>
-                                <th align="left">
-                                    <Credits /> Per User
-                                </th>
-                                <th align="left">Realm</th>
-                                <th align="right">Users</th>
-                                <th align="right">CODE</th>
-                                <th align="right">URL</th>
-                                <th align="left">EDIT</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {invites.map(
-                                ([
-                                    code,
-                                    {
-                                        credits,
-                                        credits_per_user,
-                                        joined_user_ids,
-                                        realm_id,
-                                    },
-                                ]) => (
-                                    <tr key={code}>
-                                        <td align="left">
-                                            <input
-                                                type="number"
-                                                style={{ width: "100px" }}
-                                                defaultValue={credits}
-                                                onBlur={(event) =>
-                                                    updateInvite(
-                                                        code,
-                                                        "credits",
-                                                        +event.target.value,
-                                                    )
-                                                }
-                                            />
-                                        </td>
-                                        <td align="left">
-                                            <code>{credits_per_user}</code>
-                                        </td>
-                                        <td align="left">
-                                            <input
-                                                type="text"
-                                                style={{ width: "100px" }}
-                                                defaultValue={realm_id || ""}
-                                                onBlur={(event) =>
-                                                    updateInvite(
-                                                        code,
-                                                        "realm_id",
-                                                        event.target.value
-                                                            .toUpperCase()
-                                                            .replaceAll(
-                                                                "/",
-                                                                "",
-                                                            ),
-                                                    )
-                                                }
-                                            />
-                                        </td>
-                                        <td align="right">
-                                            <UserList ids={joined_user_ids} />
-                                        </td>
-                                        <td align="right">
-                                            <CopyToClipboard
-                                                value={code.toUpperCase()}
-                                            />
-                                        </td>
-                                        <td align="right">
-                                            <CopyToClipboard
-                                                value={`${location.protocol}//${location.host}/#/welcome/${code}`}
-                                                displayMap={(url) =>
-                                                    bigScreen()
-                                                        ? url
-                                                        : "<too long>"
-                                                }
-                                            />
-                                        </td>
-                                        <td align="right">
-                                            <ButtonWithLoading
-                                                classNameArg="active"
-                                                onClick={saveInvites}
-                                                label="SAVE"
-                                            />
-                                        </td>
-                                    </tr>
-                                ),
-                            )}
-                        </tbody>
-                    </table>
+                    <div className="column_container">
+                        <table style={{ width: "100%" }}>
+                            <thead>
+                                <tr>
+                                    <th align="left">
+                                        <Credits />
+                                    </th>
+                                    <th align="left">
+                                        <Credits /> Per User
+                                    </th>
+                                    <th align="left">Realm</th>
+                                    <th align="right">Users</th>
+                                    <th align="right">CODE</th>
+                                    <th align="right">URL</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {invites.map(
+                                    ([
+                                        code,
+                                        {
+                                            credits,
+                                            credits_per_user,
+                                            joined_user_ids,
+                                            realm_id,
+                                        },
+                                    ]) => (
+                                        <tr key={code}>
+                                            <td align="left">
+                                                <input
+                                                    type="number"
+                                                    style={{ width: "100px" }}
+                                                    defaultValue={credits}
+                                                    onBlur={(event) =>
+                                                        updateInvite(
+                                                            code,
+                                                            "credits",
+                                                            +event.target.value,
+                                                        )
+                                                    }
+                                                />
+                                            </td>
+                                            <td align="left">
+                                                <code>{credits_per_user}</code>
+                                            </td>
+                                            <td align="left">
+                                                <input
+                                                    type="text"
+                                                    style={{ width: "100px" }}
+                                                    defaultValue={
+                                                        realm_id || ""
+                                                    }
+                                                    onBlur={(event) =>
+                                                        updateInvite(
+                                                            code,
+                                                            "realm_id",
+                                                            event.target.value
+                                                                .toUpperCase()
+                                                                .replaceAll(
+                                                                    "/",
+                                                                    "",
+                                                                ),
+                                                        )
+                                                    }
+                                                />
+                                            </td>
+                                            <td align="right">
+                                                <UserList
+                                                    ids={joined_user_ids}
+                                                />
+                                            </td>
+                                            <td align="right">
+                                                <CopyToClipboard
+                                                    value={code.toUpperCase()}
+                                                />
+                                            </td>
+                                            <td align="right">
+                                                <CopyToClipboard
+                                                    value={`${location.protocol}//${location.host}/#/welcome/${code}`}
+                                                    displayMap={(url) =>
+                                                        bigScreen()
+                                                            ? url
+                                                            : "<too long>"
+                                                    }
+                                                />
+                                            </td>
+                                        </tr>
+                                    ),
+                                )}
+                            </tbody>
+                        </table>
+                        <ButtonWithLoading
+                            classNameArg="active"
+                            onClick={saveInvites}
+                            label="SAVE"
+                            disabled={
+                                !invites.some(([_, invite]) => invite.dirty)
+                            }
+                        />{" "}
+                    </div>
                 )}
             </div>
         </>

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -55,7 +55,14 @@ export const Invites = () => {
                     : null,
             )
             .then((response) => {
-                if ("Err" in (response || {})) alert(`Error: ${response.Err}`);
+                if ("Err" in (response || {})) {
+                    alert(`Error: ${response.Err}`);
+                    setBusy(true);
+                    setTimeout(() => {
+                        loadInvites(); // Set back to prior state
+                        setBusy(false);
+                    }, 0);
+                }
             });
     };
 
@@ -105,7 +112,7 @@ export const Invites = () => {
                         The invite will not work if your invite budget or credit
                         balance drops below the amount attached to the invite.
                     </li>
-                    <li>Invites are not cancelable.</li>
+                    <li>Invites can be canceled by setting the credits to 0.</li>
                 </ul>
                 <div className="vcentered">
                     Credits:

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -162,7 +162,11 @@ export const Invites = () => {
                             value={inviteRealm}
                             className="max_width_col top_spaced bottom_spaced"
                             onChange={(event) =>
-                                setInviteRealm(event.target.value)
+                                setInviteRealm(
+                                    event.target.value
+                                        .replaceAll("/", "")
+                                        .toUpperCase(),
+                                )
                             }
                         />
                         <ButtonWithLoading

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -35,6 +35,19 @@ export const Invites = () => {
         loadInvites();
     }, []);
 
+    const create = async () => {
+        setBusy(true);
+        const result = await window.api.call<any>(
+            "create_invite",
+            credits,
+            credits_per_user,
+            inviteRealm,
+        );
+        if ("Err" in result) alert(`Failed: ${result.Err}`);
+        else loadInvites();
+        setBusy(false);
+    };
+
     const update = async (code: string) => {
         const updatedInvite = updatedInvites.find(
             ({ code: inviteCode }) => code === inviteCode,
@@ -140,26 +153,11 @@ export const Invites = () => {
                         className="max_width_col"
                         onChange={(event) => setInviteRealm(event.target.value)}
                     />
-                    {!busy && (
-                        <button
-                            className="vertically_spaced active"
-                            onClick={async () => {
-                                setBusy(true);
-                                const result = await window.api.call<any>(
-                                    "create_invite",
-                                    credits,
-                                    credits_per_user,
-                                    inviteRealm,
-                                );
-                                if ("Err" in result)
-                                    alert(`Failed: ${result.Err}`);
-                                else loadInvites();
-                                setBusy(false);
-                            }}
-                        >
-                            CREATE
-                        </button>
-                    )}
+                    <ButtonWithLoading
+                        classNameArg="vertically_spaced active"
+                        onClick={create}
+                        label="CREATE"
+                    />
                 </div>
                 {invites.length > 0 && <h3>Your invites</h3>}
                 {busy && <Loading />}

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -112,7 +112,9 @@ export const Invites = () => {
                         The invite will not work if your invite budget or credit
                         balance drops below the amount attached to the invite.
                     </li>
-                    <li>Invites can be canceled by setting the credits to 0.</li>
+                    <li>
+                        Invites can be canceled by setting the credits to 0.
+                    </li>
                 </ul>
                 <div className="vcentered">
                     Credits:

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -229,7 +229,12 @@ export const Invites = () => {
                                                     updateInviteValue(
                                                         code,
                                                         "realm_id",
-                                                        event.target.value,
+                                                        event.target.value
+                                                            .toUpperCase()
+                                                            .replaceAll(
+                                                                "/",
+                                                                "",
+                                                            ),
                                                     )
                                                 }
                                             />

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -54,14 +54,12 @@ export const Invites = () => {
                     ? updatedInvite.realm_id
                     : null,
             )
-            .then((response) => {
+            .then(async (response) => {
                 if ("Err" in (response || {})) {
                     alert(`Error: ${response.Err}`);
                     setBusy(true);
-                    setTimeout(() => {
-                        loadInvites(); // Set back to prior state
-                        setBusy(false);
-                    }, 0);
+                    await loadInvites(); // Set back to prior state
+                    setBusy(false);
                 }
             });
     };

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -101,63 +101,76 @@ export const Invites = () => {
     return (
         <>
             <HeadBar title="INVITES" shareLink="invites" />
-            <div className="spaced">
-                <h2>Create an invite</h2>
-                <ul>
-                    <li>
-                        You can invite new users to{" "}
-                        {window.backendCache.config.name} by creating invites
-                        for them.
-                    </li>
-                    <li>
-                        Every invite is a funded by at least{" "}
-                        <code>
-                            {
-                                window.backendCache.config
-                                    .min_credits_for_inviting
+            <div className="spaced bottom_spaced">
+                <div className="stands_out">
+                    <h2>Invite creation</h2>
+                    <ul>
+                        <li>
+                            You can invite new users to{" "}
+                            {window.backendCache.config.name} by creating
+                            invites for them.
+                        </li>
+                        <li>
+                            Every invite is a pre-charged with at least{" "}
+                            <code>
+                                {
+                                    window.backendCache.config
+                                        .min_credits_for_inviting
+                                }
+                            </code>{" "}
+                            credits: you will be charged once the invite is
+                            used.
+                        </li>
+                        <li>
+                            One invite can be used by multiple users, each
+                            receiving a pre-defined amount of credits.
+                        </li>
+                        <li>
+                            The invite will not work if your credit balance
+                            drops below the amount attached to the invite.
+                        </li>
+                        <li>
+                            In an invite specifies a realm, users joining via
+                            this invite will automartically join the realm.
+                        </li>
+                        <li>
+                            Invites can be canceled by setting the credits to 0.
+                        </li>
+                    </ul>
+                    <div className="column_container">
+                        Total credits
+                        <input
+                            type="number"
+                            value={credits}
+                            className="max_width_col top_spaced bottom_spaced"
+                            onChange={(event) =>
+                                setCredits(parseInt(event.target.value))
                             }
-                        </code>{" "}
-                        credits: you will be charged once the invite is used.
-                    </li>
-                    <li>
-                        The invite will not work if your invite budget or credit
-                        balance drops below the amount attached to the invite.
-                    </li>
-                    <li>
-                        Invites can be canceled by setting the credits to 0.
-                    </li>
-                </ul>
-                <div className="vcentered">
-                    Credits:
-                    <input
-                        type="number"
-                        value={credits}
-                        className="max_width_col"
-                        onChange={(event) =>
-                            setCredits(parseInt(event.target.value))
-                        }
-                    />
-                    Per user:
-                    <input
-                        type="number"
-                        value={credits_per_user}
-                        className="max_width_col"
-                        onChange={(event) =>
-                            setCreditsPerUser(parseInt(event.target.value))
-                        }
-                    />
-                    Realm:
-                    <input
-                        type="text"
-                        value={inviteRealm}
-                        className="max_width_col"
-                        onChange={(event) => setInviteRealm(event.target.value)}
-                    />
-                    <ButtonWithLoading
-                        classNameArg="vertically_spaced active"
-                        onClick={create}
-                        label="CREATE"
-                    />
+                        />
+                        Spend per user
+                        <input
+                            type="number"
+                            value={credits_per_user}
+                            className="max_width_col top_spaced bottom_spaced"
+                            onChange={(event) =>
+                                setCreditsPerUser(parseInt(event.target.value))
+                            }
+                        />
+                        Realm (optional)
+                        <input
+                            type="text"
+                            value={inviteRealm}
+                            className="max_width_col top_spaced bottom_spaced"
+                            onChange={(event) =>
+                                setInviteRealm(event.target.value)
+                            }
+                        />
+                        <ButtonWithLoading
+                            classNameArg="active"
+                            onClick={create}
+                            label="CREATE"
+                        />
+                    </div>
                 </div>
                 {invites.length > 0 && <h3>Your invites</h3>}
                 {busy && <Loading />}

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -13,8 +13,7 @@ interface Invite {
     credits_per_user: number;
     joined_user_ids: number[];
     realm_id?: string | null | undefined;
-    /** Owner id */
-    user_id: number;
+    inviter_user_id: number;
 }
 
 export const Invites = () => {
@@ -56,7 +55,7 @@ export const Invites = () => {
                     : null,
             )
             .then((response) => {
-                if ("Err" in response) alert(`Error: ${response.Err}`);
+                if ("Err" in (response || {})) alert(`Error: ${response.Err}`);
             });
     };
 

--- a/src/frontend/src/invites.tsx
+++ b/src/frontend/src/invites.tsx
@@ -7,6 +7,7 @@ import {
     Loading,
 } from "./common";
 import { Credits } from "./icons";
+import { UserList } from "./user_resolve";
 
 interface Invite {
     credits: number;
@@ -244,17 +245,7 @@ export const Invites = () => {
                                             />
                                         </td>
                                         <td align="right">
-                                            {joined_user_ids.map((userId) => (
-                                                <a
-                                                    key={
-                                                        userId + "_joined_user"
-                                                    }
-                                                    target="_blank"
-                                                    href={`#/user/${userId}`}
-                                                >
-                                                    {userId}&nbsp;
-                                                </a>
-                                            ))}
+                                            <UserList ids={joined_user_ids} />
                                         </td>
                                         <td align="right">
                                             <CopyToClipboard
@@ -275,7 +266,7 @@ export const Invites = () => {
                                             <ButtonWithLoading
                                                 classNameArg="active"
                                                 onClick={() => update(code)}
-                                                label="EDIT"
+                                                label="SAVE"
                                             />
                                         </td>
                                     </tr>

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -144,10 +144,10 @@ export const Settings = ({ invite }: { invite?: string }) => {
             }
         }
         if (registrationFlow) {
+            await window.reloadUser();
             location.href = registrationRealmId
                 ? `/#/realm/${registrationRealmId}`
                 : "/";
-            location.reload();
         } else if (nameChange) location.href = "/";
         else if (uiRefresh) {
             await window.reloadUser();

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -143,11 +143,12 @@ export const Settings = ({ invite }: { invite?: string }) => {
                 return;
             }
         }
-        if (registrationFlow)
+        if (registrationFlow) {
             location.href = registrationRealmId
                 ? `/#/realm/${registrationRealmId}`
                 : "/";
-        else if (nameChange) location.href = "/";
+            location.reload();
+        } else if (nameChange) location.href = "/";
         else if (uiRefresh) {
             await window.reloadUser();
             window.uiInitialized = false;

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -81,6 +81,7 @@ export const Settings = ({ invite }: { invite?: string }) => {
 
     const submit = async () => {
         const registrationFlow = !user;
+        let registrationRealmId: string | undefined;
         if (registrationFlow) {
             let response = await window.api.call<any>(
                 "create_user",
@@ -90,6 +91,7 @@ export const Settings = ({ invite }: { invite?: string }) => {
             if ("Err" in response) {
                 return alert(`Error: ${response.Err}`);
             }
+            registrationRealmId = response?.Ok;
         }
 
         const nameChange = !registrationFlow && user.name != name;
@@ -141,7 +143,11 @@ export const Settings = ({ invite }: { invite?: string }) => {
                 return;
             }
         }
-        if (registrationFlow || nameChange) location.href = "/";
+        if (registrationFlow)
+            location.href = registrationRealmId
+                ? `/#/realm/${registrationRealmId}`
+                : "/";
+        else if (nameChange) location.href = "/";
         else if (uiRefresh) {
             await window.reloadUser();
             window.uiInitialized = false;


### PR DESCRIPTION
Feature request: https://taggr.network/#/post/1333906

- Extend invites to struct: credits, credits_per_user, realm_id, joined_by_user_ids
- Change create_invite
   - add new parameters and validate edge cases
- Update update_invite:
  -  owner can increase credits allowed to consume on invite
  -   owner can change realm_id
- Implement frontend requirements
  - Revamp invite page
  - Registration flow: if invite has realm_id, navigate user to that realm. Avoid showing him Mint credits page
- Protect transfering credits to 1 account (any of below it passes) `user::validate_send_credits`
  - invited user consumed amount of credits from invite
  - invited user purchased new credits
- Addtionally: create_invite has small vulnerability, anyone can create Infinite number of invites without paying anything. It can consume heap memory. Fixed within `invite::validate_user_invites_credits`
  - checking if ALL invites credits are smaller than owners amount of credits
