### PR TITLE
Fix failing E2E test: test1.spec.ts/Wallet

### DIFF
--- a/src/backend/dev_helpers.rs
+++ b/src/backend/dev_helpers.rs
@@ -24,7 +24,14 @@ async fn reset() {
         cell.replace(state);
     });
     set_timer(Duration::from_millis(0), || {
-        spawn(State::fetch_xdr_rate());
+        spawn(async {
+            let old_xdr_rate = State::get_xdr_rate();
+            State::fetch_xdr_rate().await;
+            let new_xdr_rate = State::get_xdr_rate();
+            // Check that fetching of the rate worked.
+            assert_ne!(old_xdr_rate, new_xdr_rate);
+            State::reset_xdr_rate_for_testing();
+        });
     });
 }
 

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1728,6 +1728,17 @@ impl State {
         }
     }
 
+    pub fn get_xdr_rate() -> u64 {
+        read(|state| state.e8s_for_one_xdr)
+    }
+
+    pub fn reset_xdr_rate_for_testing() {
+        mutate(|state| {
+            // If this is set to 1_000_000 and above, then E2E tests fail.
+            state.e8s_for_one_xdr = 900_000;
+        });
+    }
+
     pub async fn hourly_chores(now: u64) {
         mutate(|state| {
             state.backup_exists = false;

--- a/src/backend/env/mod.rs
+++ b/src/backend/env/mod.rs
@@ -1732,6 +1732,7 @@ impl State {
         read(|state| state.e8s_for_one_xdr)
     }
 
+    #[cfg(any(test, feature = "dev"))]
     pub fn reset_xdr_rate_for_testing() {
         mutate(|state| {
             // If this is set to 1_000_000 and above, then E2E tests fail.


### PR DESCRIPTION
Setup.ts of E2E test calls `dfx canister call taggr reset` that fetches an external xdr rate.

This patch initializes the xdr rate to a fixed value to make tests less fragile.
