### PR TITLE
feat: adds toggle for displaying previous usernames

### DIFF
--- a/src/frontend/src/profile.tsx
+++ b/src/frontend/src/profile.tsx
@@ -311,14 +311,17 @@ export const UserInfo = ({ profile }: { profile: User }) => {
 
     return (
         <div className="spaced">
-            {profile.previous_names.length > 0 && (
-                <div className="bottom_spaced">
-                    AKA:{" "}
-                    {commaSeparated(
-                        profile.previous_names.map((handle) => <b>{handle}</b>),
-                    )}
-                </div>
-            )}
+            {profile.previous_names.length > 0 &&
+                profile.settings.show_aliases !== "off" && (
+                    <div className="bottom_spaced">
+                        AKA:{" "}
+                        {commaSeparated(
+                            profile.previous_names.map((handle) => (
+                                <b>{handle}</b>
+                            )),
+                        )}
+                    </div>
+                )}
             {profile.about ? (
                 <>
                     <Content classNameArg="larger_text" value={profile.about} />

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -168,6 +168,22 @@ export const Settings = ({ invite }: { invite?: string }) => {
         await window.reloadUser();
     };
 
+    const handleCheckboxSetting = (
+        key: string,
+        event: React.ChangeEvent<HTMLInputElement>,
+    ) => {
+        const { checked } = event.target;
+        switch (checked) {
+            case true:
+                event.target.value = "on";
+                break;
+            case false:
+                event.target.value = "off";
+                break;
+        }
+        setSetting(key, event);
+    };
+
     return (
         <>
             <HeadBar title="SETTINGS" shareLink="setting" />
@@ -183,6 +199,21 @@ export const Settings = ({ invite }: { invite?: string }) => {
                     placeholder="alphanumeric"
                     onChange={namePicker}
                 />
+                {
+                    <div
+                        className={`bottom_spaced row_container gap ${user?.previous_names?.length > 0 ? "" : "hidden"}`}
+                    >
+                        <div className="bottom_half_spaced">Show Aliases</div>
+                        <input
+                            type="checkbox"
+                            checked={settings.show_aliases !== "off"}
+                            onChange={(e) =>
+                                handleCheckboxSetting("show_aliases", e)
+                            }
+                            id="show_aliases"
+                        />
+                    </div>
+                }
                 {user && pfp && (
                     <>
                         <div className="bottom_half_spaced">Avataggr</div>

--- a/src/frontend/src/settings.tsx
+++ b/src/frontend/src/settings.tsx
@@ -201,9 +201,8 @@ export const Settings = ({ invite }: { invite?: string }) => {
                 />
                 {
                     <div
-                        className={`bottom_spaced row_container gap ${user?.previous_names?.length > 0 ? "" : "hidden"}`}
+                        className={`bottom_spaced ${user?.previous_names?.length > 0 ? "" : "hidden"}`}
                     >
-                        <div className="bottom_half_spaced">Show Aliases</div>
                         <input
                             type="checkbox"
                             checked={settings.show_aliases !== "off"}
@@ -212,6 +211,12 @@ export const Settings = ({ invite }: { invite?: string }) => {
                             }
                             id="show_aliases"
                         />
+                        <label
+                            className="left_half_spaced"
+                            htmlFor="show_aliases"
+                        >
+                            Show Aliases
+                        </label>
                     </div>
                 }
                 {user && pfp && (

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -817,11 +817,6 @@ a.reply_tag {
     flex-wrap: wrap;
 }
 
-.gap {
-    column-gap: 1em;
-    row-gap: 1em;
-}
-
 .max_width_col {
     flex: 1;
 }

--- a/src/frontend/src/style.css
+++ b/src/frontend/src/style.css
@@ -817,6 +817,11 @@ a.reply_tag {
     flex-wrap: wrap;
 }
 
+.gap {
+    column-gap: 1em;
+    row-gap: 1em;
+}
+
 .max_width_col {
     flex: 1;
 }
@@ -1200,6 +1205,10 @@ div.thumbnails img {
     position: relative;
     display: flex;
     justify-content: center;
+}
+
+.hidden {
+    display: none;
 }
 
 div.thumbnails {


### PR DESCRIPTION
<img width="395" alt="image" src="https://github.com/user-attachments/assets/7524dfc5-e976-48b4-ba50-964efc109cdd" />

For users who have changed account handles, adds a toggle to display or hide previous account names on their public profile. Doesn't change the record or forwarding, just the display of the AKA field. Defaults to true

Developer Note: leaving the field in but hidden is intentional - this way the value gets set during profile updates or creation.