### PR TITLE
Migrate to id.ai with guided upgrade flag

### DIFF
--- a/src/frontend/src/authentication.tsx
+++ b/src/frontend/src/authentication.tsx
@@ -99,32 +99,6 @@ export const authMethods = [
             />
         ),
     },
-    {
-        icon: <Infinity />,
-        label: "Internet Identity (Legacy)",
-        deprecated: true,
-        description:
-            "Decentralized authentication service hosted on IC and based on biometric devices.",
-        login: async (signUp?: boolean) => {
-            if (
-                (location.href.includes(".raw") ||
-                    location.href.includes("share.")) &&
-                confirm(
-                    "You're using an uncertified, insecure frontend. Do you want to be re-routed to the certified one?",
-                )
-            ) {
-                location.href = location.href.replace(".raw", "");
-                return null;
-            }
-            window.authClient.login({
-                onSuccess: () => finalize(signUp),
-                identityProvider: "https://identity.ic0.app",
-                maxTimeToLive: BigInt(30 * 24 * 3600000000000),
-                derivationOrigin: window.location.origin,
-            });
-            return null;
-        },
-    },
 ];
 
 const finalize = async (signUp?: boolean) => {
@@ -184,7 +158,7 @@ export const LoginMasks = ({
                         {methods.map((method) => (
                             <div
                                 key={method.label}
-                                className={`left_spaced right_spaced bottom_spaced ${method.deprecated ? "inactive" : ""}`}
+                                className="left_spaced right_spaced bottom_spaced"
                             >
                                 <ButtonWithLoading
                                     key={method.label}

--- a/src/frontend/src/env.ts
+++ b/src/frontend/src/env.ts
@@ -7,5 +7,5 @@ export const MAINNET_MODE = STAGING_MODE || process.env.DFX_NETWORK == "ic";
 export const CANISTER_ID = process.env.CANISTER_ID || "";
 
 export const II_URL = MAINNET_MODE
-    ? "https://id.ai"
+    ? "https://id.ai/?feature_flag_guided_upgrade=true"
     : "http://localhost:9090/?canisterId=qhbym-qaaaa-aaaaa-aaafq-cai";


### PR DESCRIPTION
tldr: Internet Identity has migrated to id.ai, and legacy identity.ic0.app is no longer necessary as it now redirects to id.ai. Following the migration guide from: https://forum.dfinity.org/t/migrate-your-app-to-id-ai-for-internet-identity-sign-in/63708

- Remove legacy Internet Identity method
- Add feature_flag_guided_upgrade=true parameter